### PR TITLE
feat: add admin endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/gin-gonic/gin v1.6.3
-	github.com/go-vela/mock v0.6.1-0.20201016123844-ce8b022539be
+	github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2
 	github.com/go-vela/types v0.6.0
 	github.com/google/go-querystring v1.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/gin-gonic/gin v1.6.3
-	github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2
+	github.com/go-vela/mock v0.6.1-0.20201117151110-522ea7d3ede0
 	github.com/go-vela/types v0.6.0
 	github.com/google/go-querystring v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.0 h1:72qIR/m8ybvL8L5TIyfgrigqkrw7kVYAvjEvpT85l70=
 github.com/go-playground/validator/v10 v10.4.0/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2 h1:kxv4q8jqPZWwzcEbjTtWAC4gsm4RdG1cX3QHzSlmlD8=
-github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
+github.com/go-vela/mock v0.6.1-0.20201117151110-522ea7d3ede0 h1:S3935izuG7gqboMZ4wlOfaw6k5YE7DXuMC2rIy62izI=
+github.com/go-vela/mock v0.6.1-0.20201117151110-522ea7d3ede0/go.mod h1:Jfytw5IJd7gs6Wahb+DMhDZI+xY7UJ+2AAErqfZdERk=
 github.com/go-vela/types v0.6.0 h1:82/+Y3EGnnr37HeaJ5qhz/PGMvLkJfYvblEw1kFwxb4=
 github.com/go-vela/types v0.6.0/go.mod h1:G1Qp0JFtXV+QRNTEWXht+WdllOhjAGapg9vBZKdj6N0=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,14 @@ github.com/go-playground/validator/v10 v10.4.0 h1:72qIR/m8ybvL8L5TIyfgrigqkrw7kV
 github.com/go-playground/validator/v10 v10.4.0/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-vela/mock v0.6.1-0.20201016123844-ce8b022539be h1:q/YVXnsLvSUfIwObvb/waPrMqFX00tRwi73sKkat9nM=
 github.com/go-vela/mock v0.6.1-0.20201016123844-ce8b022539be/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
+github.com/go-vela/mock v0.6.1-0.20201113201601-01b902cdb796 h1:SY25DzFt+Y4famGpwvtkWQbTKY3ae2wtbDWEOfpR4Ns=
+github.com/go-vela/mock v0.6.1-0.20201113201601-01b902cdb796/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
+github.com/go-vela/mock v0.6.1-0.20201116160832-39af751e818c h1:JAO45BWy3quAh+fKKXe9TuzfS+fRKa4lQs6/d3XgC60=
+github.com/go-vela/mock v0.6.1-0.20201116160832-39af751e818c/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
+github.com/go-vela/mock v0.6.1-0.20201116163453-1880690b0cd0 h1:Rr/58x3jFF81VnHWh84DEsGvlZoNQWU0TOBOGecBe3Q=
+github.com/go-vela/mock v0.6.1-0.20201116163453-1880690b0cd0/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
+github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2 h1:kxv4q8jqPZWwzcEbjTtWAC4gsm4RdG1cX3QHzSlmlD8=
+github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
 github.com/go-vela/types v0.6.0 h1:82/+Y3EGnnr37HeaJ5qhz/PGMvLkJfYvblEw1kFwxb4=
 github.com/go-vela/types v0.6.0/go.mod h1:G1Qp0JFtXV+QRNTEWXht+WdllOhjAGapg9vBZKdj6N0=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/go.sum
+++ b/go.sum
@@ -37,14 +37,6 @@ github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.0 h1:72qIR/m8ybvL8L5TIyfgrigqkrw7kVYAvjEvpT85l70=
 github.com/go-playground/validator/v10 v10.4.0/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-vela/mock v0.6.1-0.20201016123844-ce8b022539be h1:q/YVXnsLvSUfIwObvb/waPrMqFX00tRwi73sKkat9nM=
-github.com/go-vela/mock v0.6.1-0.20201016123844-ce8b022539be/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
-github.com/go-vela/mock v0.6.1-0.20201113201601-01b902cdb796 h1:SY25DzFt+Y4famGpwvtkWQbTKY3ae2wtbDWEOfpR4Ns=
-github.com/go-vela/mock v0.6.1-0.20201113201601-01b902cdb796/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
-github.com/go-vela/mock v0.6.1-0.20201116160832-39af751e818c h1:JAO45BWy3quAh+fKKXe9TuzfS+fRKa4lQs6/d3XgC60=
-github.com/go-vela/mock v0.6.1-0.20201116160832-39af751e818c/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
-github.com/go-vela/mock v0.6.1-0.20201116163453-1880690b0cd0 h1:Rr/58x3jFF81VnHWh84DEsGvlZoNQWU0TOBOGecBe3Q=
-github.com/go-vela/mock v0.6.1-0.20201116163453-1880690b0cd0/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
 github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2 h1:kxv4q8jqPZWwzcEbjTtWAC4gsm4RdG1cX3QHzSlmlD8=
 github.com/go-vela/mock v0.6.1-0.20201116171609-ad996c776db2/go.mod h1:8+LjyuYsei05/9LpFa2Praj2+92FWMyeOu4GAukB7Xg=
 github.com/go-vela/types v0.6.0 h1:82/+Y3EGnnr37HeaJ5qhz/PGMvLkJfYvblEw1kFwxb4=

--- a/vela/admin.go
+++ b/vela/admin.go
@@ -1,0 +1,346 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package vela
+
+import (
+	"fmt"
+
+	"github.com/go-vela/types/library"
+)
+
+type (
+	// AdminService handles retrieving builds from
+	// the server methods of the Vela API.
+	AdminService struct {
+		Build      *AdminBuildService
+		Deployment *AdminDeploymentService
+		Hook       *AdminHookService
+		Repo       *AdminRepoService
+		Secret     *AdminSecretService
+		Service    *AdminSvcService
+		Step       *AdminStepService
+		User       *AdminUserService
+	}
+
+	// AdminBuildService handles retrieving admin builds from
+	// the server methods of the Vela API.
+	AdminBuildService service
+
+	// AdminDeploymentService handles retrieving admin deployments from
+	// the server methods of the Vela API.
+	AdminDeploymentService service
+
+	// AdminHookService handles retrieving admin hooks from
+	// the server methods of the Vela API.
+	AdminHookService service
+
+	// AdminRepoService handles retrieving admin repos from
+	// the server methods of the Vela API.
+	AdminRepoService service
+
+	// AdminSecretService handles retrieving admin secrets from
+	// the server methods of the Vela API.
+	AdminSecretService service
+
+	// AdminSvcService handles retrieving admin services from
+	// the server methods of the Vela API.
+	AdminSvcService service
+
+	// AdminStepService handles retrieving admin steps from
+	// the server methods of the Vela API.
+	AdminStepService service
+
+	// AdminUserService handles retrieving admin users from
+	// the server methods of the Vela API.
+	AdminUserService service
+)
+
+// GetAll returns a list of all builds.
+// nolint
+func (svc *AdminBuildService) GetAll(opt *ListOptions) (*[]library.Build, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/builds")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Build type we want to return
+	v := new([]library.Build)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a build with the provided details.
+// nolint
+func (svc *AdminBuildService) Update(b *library.Build) (*library.Build, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/build")
+
+	// library Build type we want to return
+	v := new(library.Build)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, b, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all deployments.
+// nolint
+func (svc *AdminDeploymentService) GetAll(opt *ListOptions) (*[]library.Deployment, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/deployments")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Deployment type we want to return
+	v := new([]library.Deployment)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a deployment with the provided details.
+// nolint
+func (svc *AdminDeploymentService) Update(d *library.Deployment) (*library.Deployment, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/deployment")
+
+	// library Deployment type we want to return
+	v := new(library.Deployment)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, d, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all hooks.
+// nolint
+func (svc *AdminHookService) GetAll(opt *ListOptions) (*[]library.Hook, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/hooks")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Hook type we want to return
+	v := new([]library.Hook)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a hook with the provided details.
+// nolint
+func (svc *AdminHookService) Update(h *library.Hook) (*library.Hook, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/hook")
+
+	// library Hook type we want to return
+	v := new(library.Hook)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, h, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all repos.
+// nolint
+func (svc *AdminRepoService) GetAll(opt *ListOptions) (*[]library.Repo, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/repos")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Repo type we want to return
+	v := new([]library.Repo)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a repo with the provided details.
+// nolint
+func (svc *AdminRepoService) Update(r *library.Repo) (*library.Repo, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/repo")
+
+	// library Repo type we want to return
+	v := new(library.Repo)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, r, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all secrets.
+// nolint
+func (svc *AdminSecretService) GetAll(opt *ListOptions) (*[]library.Secret, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/secrets")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Secret type we want to return
+	v := new([]library.Secret)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a secret with the provided details.
+// nolint
+func (svc *AdminSecretService) Update(s *library.Secret) (*library.Secret, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/secret")
+
+	// library Secret type we want to return
+	v := new(library.Secret)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, s, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all services.
+// nolint
+func (svc *AdminSvcService) GetAll(opt *ListOptions) (*[]library.Service, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/services")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Service type we want to return
+	v := new([]library.Service)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a service with the provided details.
+// nolint
+func (svc *AdminSvcService) Update(s *library.Service) (*library.Service, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/service")
+
+	// library Service type we want to return
+	v := new(library.Service)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, s, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all steps.
+// nolint
+func (svc *AdminStepService) GetAll(opt *ListOptions) (*[]library.Step, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/steps")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library Step type we want to return
+	v := new([]library.Step)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a step with the provided details.
+// nolint
+func (svc *AdminStepService) Update(s *library.Step) (*library.Step, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/step")
+
+	// library Step type we want to return
+	v := new(library.Step)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", u, s, v)
+
+	return v, resp, err
+}
+
+// GetAll returns a list of all users.
+// nolint
+func (svc *AdminUserService) GetAll(opt *ListOptions) (*[]library.User, *Response, error) {
+	// set the API endpoint path we send the request to
+	u := fmt.Sprintf("/api/v1/admin/users")
+
+	// add optional arguments if supplied
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// slice library User type we want to return
+	v := new([]library.User)
+
+	// send request using client
+	resp, err := svc.client.Call("GET", u, nil, v)
+
+	return v, resp, err
+}
+
+// Update modifies a user with the provided details.
+// nolint
+func (svc *AdminUserService) Update(u *library.User) (*library.User, *Response, error) {
+	// set the API endpoint path we send the request to
+	url := fmt.Sprintf("/api/v1/admin/user")
+
+	// library User type we want to return
+	v := new(library.User)
+
+	// send request using client
+	resp, err := svc.client.Call("PUT", url, u, v)
+
+	return v, resp, err
+}

--- a/vela/admin_test.go
+++ b/vela/admin_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+//nolint:dupl // ignores duplicate client instantiation code
 package vela
 
 import (

--- a/vela/admin_test.go
+++ b/vela/admin_test.go
@@ -1,0 +1,515 @@
+package vela
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-vela/mock/server"
+	"github.com/go-vela/types/library"
+)
+
+func TestAdmin_Build_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.BuildsResp)
+
+	var want []library.Build
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Build.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Build returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Build returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Build getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Build_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.BuildResp)
+
+	var want library.Build
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Build{
+		Number: Int(1),
+		Parent: Int(1),
+		Event:  String("push"),
+		Status: String("running"),
+	}
+
+	// run test
+	got, resp, err := c.Admin.Build.Update(&req)
+
+	if err != nil {
+		t.Errorf("Build returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Build returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Build update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Deployment_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.DeploymentsResp)
+
+	var want []library.Deployment
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Deployment.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Deployment returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Deployment returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Deployment getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Deployment_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.DeploymentResp)
+
+	var want library.Deployment
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Deployment{
+		Commit:      String("48afb5bdc41ad69bf22588491333f7cf71135163"),
+		Ref:         String("refs/heads/master"),
+		Task:        String("vela-deploy"),
+		Target:      String("production"),
+		Description: String("Deployment request from Vela"),
+	}
+
+	// run test
+	got, resp, err := c.Admin.Deployment.Update(&req)
+
+	if err != nil {
+		t.Errorf("Deployment returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Deployment returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Deployment update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Hook_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.HooksResp)
+
+	var want []library.Hook
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Hook.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Hook returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Hook returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Hook getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Hook_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.HookResp)
+
+	var want library.Hook
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Hook{
+		Number: Int(1),
+		Event:  String("push"),
+		Status: String("success"),
+	}
+
+	// run test
+	got, resp, err := c.Admin.Hook.Update(&req)
+
+	if err != nil {
+		t.Errorf("Hook returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Hook returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Hook update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Repo_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.ReposResp)
+
+	var want []library.Repo
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Repo.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Repo returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Repo returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Repo getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Repo_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.RepoResp)
+
+	var want library.Repo
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Repo{
+		Private:     Bool(true),
+		Trusted:     Bool(true),
+		Active:      Bool(true),
+		AllowPull:   Bool(true),
+		AllowPush:   Bool(true),
+		AllowDeploy: Bool(true),
+		AllowTag:    Bool(true),
+	}
+
+	// run test
+	got, resp, err := c.Admin.Repo.Update(&req)
+
+	if err != nil {
+		t.Errorf("Repo returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Repo returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Repo update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Secret_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.SecretsResp)
+
+	var want []library.Secret
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Secret.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Secret returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Secret returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Secret getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Secret_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.SecretResp)
+
+	var want library.Secret
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Secret{
+		Name:   String("foo"),
+		Value:  String("bar"),
+		Events: &[]string{"barf", "foob"},
+	}
+	// run test
+	got, resp, err := c.Admin.Secret.Update(&req)
+
+	if err != nil {
+		t.Errorf("Secret returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Secret returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Secret update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Service_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.ServicesResp)
+
+	var want []library.Service
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Service.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Service returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Service returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Service getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Service_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.ServiceResp)
+
+	var want library.Service
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Service{
+		Number:   Int(1),
+		Status:   String("finished"),
+		Started:  Int64(1563475419),
+		Finished: Int64(1563475419),
+	}
+
+	// run test
+	got, resp, err := c.Admin.Service.Update(&req)
+
+	if err != nil {
+		t.Errorf("Service returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Service returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Service update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Step_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.StepsResp)
+
+	var want []library.Step
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.Step.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("Step returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Step returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Step getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_Step_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.StepResp)
+
+	var want library.Step
+	_ = json.Unmarshal(data, &want)
+
+	req := library.Step{
+		Number:   Int(1),
+		Status:   String("finished"),
+		Started:  Int64(1563475419),
+		Finished: Int64(1563475419),
+	}
+
+	// run test
+	got, resp, err := c.Admin.Step.Update(&req)
+
+	if err != nil {
+		t.Errorf("Step returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Step returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("Step update is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_User_GetAll_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.UsersResp)
+
+	var want []library.User
+	_ = json.Unmarshal(data, &want)
+
+	// run test
+	got, resp, err := c.Admin.User.GetAll(nil)
+
+	if err != nil {
+		t.Errorf("User returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("User returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("User getall is %v, want %v", got, want)
+	}
+}
+
+func TestAdmin_User_Update_200(t *testing.T) {
+	// setup context
+	gin.SetMode(gin.TestMode)
+
+	s := httptest.NewServer(server.FakeHandler())
+	c, _ := NewClient(s.URL, nil)
+
+	data := []byte(server.UserResp)
+
+	var want library.User
+	_ = json.Unmarshal(data, &want)
+
+	req := library.User{
+		Name: String("octocat"),
+	}
+
+	// run test
+	got, resp, err := c.Admin.User.Update(&req)
+
+	if err != nil {
+		t.Errorf("User returned err: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("User returned %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+
+	if !reflect.DeepEqual(got, &want) {
+		t.Errorf("User update is %v, want %v", got, want)
+	}
+}

--- a/vela/client.go
+++ b/vela/client.go
@@ -38,6 +38,7 @@ type (
 		UserAgent string
 
 		// Vela service for authentication.
+		Admin          *AdminService
 		Authentication *AuthenticationService
 		Authorization  *AuthorizationService
 		Build          *BuildService
@@ -96,6 +97,16 @@ func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
 	// instantiate all client services
 	c.Authentication = &AuthenticationService{client: c}
 	c.Authorization = &AuthorizationService{client: c}
+	c.Admin = &AdminService{
+		&AdminBuildService{client: c},
+		&AdminDeploymentService{client: c},
+		&AdminHookService{client: c},
+		&AdminRepoService{client: c},
+		&AdminSecretService{client: c},
+		&AdminSvcService{client: c},
+		&AdminStepService{client: c},
+		&AdminUserService{client: c},
+	}
 	c.Build = &BuildService{client: c}
 	c.Deployment = &DeploymentService{client: c}
 	c.Hook = &HookService{client: c}

--- a/vela/client_test.go
+++ b/vela/client_test.go
@@ -30,6 +30,16 @@ func TestVela_NewClient(t *testing.T) {
 	}
 	want.Authentication = &AuthenticationService{client: want}
 	want.Authorization = &AuthorizationService{client: want}
+	want.Admin = &AdminService{
+		&AdminBuildService{client: want},
+		&AdminDeploymentService{client: want},
+		&AdminHookService{client: want},
+		&AdminRepoService{client: want},
+		&AdminSecretService{client: want},
+		&AdminSvcService{client: want},
+		&AdminStepService{client: want},
+		&AdminUserService{client: want},
+	}
 	want.Build = &BuildService{client: want}
 	want.Deployment = &DeploymentService{client: want}
 	want.Hook = &HookService{client: want}


### PR DESCRIPTION
This PR adds all the [admin](https://github.com/go-vela/server/tree/master/api/admin) endpoints to the SDK to make them available to admins who need to script against the endpoints.

The following is example syntax to access the admin endpoints on a client:

```go
client.Admin.Build.GetAll(nil)
```

_Note: GoDoc examples was not added at this time but can be if we think it's valuable._

Dependent PRs:
https://github.com/go-vela/mock/pull/75

fixes: go-vela/community#100