### PR TITLE
chore: linter setup and fixes, doc changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,7 +58,23 @@ cd $HOME/go-vela/sdk-go
 ```
 
 * Write your code
-  - Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please be sure to [follow our commit rules](https://chris.beams.io/posts/git-commit/#seven-rules)
+  * Please address linter warnings appropriately. If you are intentionally violating a rule that triggers a linter, please annotate the respective code with `nolint` declarations [[docs](https://golangci-lint.run/usage/false-positives/)]. we are using the following format for `nolint` declarations:
+
+    ```go
+    // nolint:<linter(s)> // <short reason>
+    ```
+  
+    Example:
+
+    ```go
+    // nolint:gocyclo // legacy function is complex, needs simplification
+    func superComplexFunction() error {
+      // ..
+    }
+    ```
+
+    Check the [documentation for more examples](https://golangci-lint.run/usage/false-positives/).
 
 * Write tests for your changes and ensure they pass:
 
@@ -83,4 +99,25 @@ go vet ./...
 git push fork master
 ```
 
-* Open a pull request. Thank you for your contribution!
+* Open a pull request!
+  * For the title of the pull request, please use the following format for the title:
+
+    ```text
+    feat(wobble): add hat wobble
+    ^--^^------^  ^------------^
+    |   |         |
+    |   |         +---> Summary in present tense.
+    |   +---> Scope: a noun describing a section of the codebase (optional)
+    +---> Type: chore, docs, feat, fix, refactor, or test.
+    ```
+
+    * feat: adds a new feature (equivalent to a MINOR in Semantic Versioning)
+    * fix: fixes a bug (equivalent to a PATCH in Semantic Versioning)
+    * docs: changes to the documentation
+    * refactor: refactors production code, eg. renaming a variable; doesn't change public API
+    * test: adds missing tests, refactors tests; no production code change
+    * chore: updates something without impacting the user (ex: bump a dependency in package.json or go.mod); no production code change
+
+    If a code change introduces a breaking change, place ! suffix after type, ie. feat(change)!: adds breaking change. correlates with MAJOR in semantic versioning.
+
+Thank you for your contribution!

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,10 +56,10 @@ linters-settings:
 
   # https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+    allow-leading-space: true # allow non-"machine-readable" format (ie. with leading space) 
+    allow-unused: false # allow nolint directives that don't address a linting issue
+    require-explanation: true # require an explanation for nolint directives
+    require-specific: true # require nolint directives to be specific about which linter is being skipped
 
 # This section provides the configuration for which linters
 # golangci will execute. Several of them were disabled by

--- a/vela/admin.go
+++ b/vela/admin.go
@@ -5,8 +5,6 @@
 package vela
 
 import (
-	"fmt"
-
 	"github.com/go-vela/types/library"
 )
 
@@ -58,10 +56,9 @@ type (
 )
 
 // GetAll returns a list of all builds.
-// nolint
 func (svc *AdminBuildService) GetAll(opt *ListOptions) (*[]library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/builds")
+	u := "/api/v1/admin/builds"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -79,10 +76,9 @@ func (svc *AdminBuildService) GetAll(opt *ListOptions) (*[]library.Build, *Respo
 }
 
 // Update modifies a build with the provided details.
-// nolint
 func (svc *AdminBuildService) Update(b *library.Build) (*library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/build")
+	u := "/api/v1/admin/build"
 
 	// library Build type we want to return
 	v := new(library.Build)
@@ -94,10 +90,11 @@ func (svc *AdminBuildService) Update(b *library.Build) (*library.Build, *Respons
 }
 
 // GetAll returns a list of all deployments.
-// nolint
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *AdminDeploymentService) GetAll(opt *ListOptions) (*[]library.Deployment, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/deployments")
+	u := "/api/v1/admin/deployments"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -115,10 +112,11 @@ func (svc *AdminDeploymentService) GetAll(opt *ListOptions) (*[]library.Deployme
 }
 
 // Update modifies a deployment with the provided details.
-// nolint
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *AdminDeploymentService) Update(d *library.Deployment) (*library.Deployment, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/deployment")
+	u := "/api/v1/admin/deployment"
 
 	// library Deployment type we want to return
 	v := new(library.Deployment)
@@ -130,10 +128,9 @@ func (svc *AdminDeploymentService) Update(d *library.Deployment) (*library.Deplo
 }
 
 // GetAll returns a list of all hooks.
-// nolint
 func (svc *AdminHookService) GetAll(opt *ListOptions) (*[]library.Hook, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/hooks")
+	u := "/api/v1/admin/hooks"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -151,10 +148,9 @@ func (svc *AdminHookService) GetAll(opt *ListOptions) (*[]library.Hook, *Respons
 }
 
 // Update modifies a hook with the provided details.
-// nolint
 func (svc *AdminHookService) Update(h *library.Hook) (*library.Hook, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/hook")
+	u := "/api/v1/admin/hook"
 
 	// library Hook type we want to return
 	v := new(library.Hook)
@@ -166,10 +162,9 @@ func (svc *AdminHookService) Update(h *library.Hook) (*library.Hook, *Response, 
 }
 
 // GetAll returns a list of all repos.
-// nolint
 func (svc *AdminRepoService) GetAll(opt *ListOptions) (*[]library.Repo, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/repos")
+	u := "/api/v1/admin/repos"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -187,10 +182,9 @@ func (svc *AdminRepoService) GetAll(opt *ListOptions) (*[]library.Repo, *Respons
 }
 
 // Update modifies a repo with the provided details.
-// nolint
 func (svc *AdminRepoService) Update(r *library.Repo) (*library.Repo, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/repo")
+	u := "/api/v1/admin/repo"
 
 	// library Repo type we want to return
 	v := new(library.Repo)
@@ -202,10 +196,9 @@ func (svc *AdminRepoService) Update(r *library.Repo) (*library.Repo, *Response, 
 }
 
 // GetAll returns a list of all secrets.
-// nolint
 func (svc *AdminSecretService) GetAll(opt *ListOptions) (*[]library.Secret, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/secrets")
+	u := "/api/v1/admin/secrets"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -223,10 +216,9 @@ func (svc *AdminSecretService) GetAll(opt *ListOptions) (*[]library.Secret, *Res
 }
 
 // Update modifies a secret with the provided details.
-// nolint
 func (svc *AdminSecretService) Update(s *library.Secret) (*library.Secret, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/secret")
+	u := "/api/v1/admin/secret"
 
 	// library Secret type we want to return
 	v := new(library.Secret)
@@ -238,10 +230,9 @@ func (svc *AdminSecretService) Update(s *library.Secret) (*library.Secret, *Resp
 }
 
 // GetAll returns a list of all services.
-// nolint
 func (svc *AdminSvcService) GetAll(opt *ListOptions) (*[]library.Service, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/services")
+	u := "/api/v1/admin/services"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -259,10 +250,9 @@ func (svc *AdminSvcService) GetAll(opt *ListOptions) (*[]library.Service, *Respo
 }
 
 // Update modifies a service with the provided details.
-// nolint
 func (svc *AdminSvcService) Update(s *library.Service) (*library.Service, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/service")
+	u := "/api/v1/admin/service"
 
 	// library Service type we want to return
 	v := new(library.Service)
@@ -274,10 +264,9 @@ func (svc *AdminSvcService) Update(s *library.Service) (*library.Service, *Respo
 }
 
 // GetAll returns a list of all steps.
-// nolint
 func (svc *AdminStepService) GetAll(opt *ListOptions) (*[]library.Step, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/steps")
+	u := "/api/v1/admin/steps"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -295,10 +284,9 @@ func (svc *AdminStepService) GetAll(opt *ListOptions) (*[]library.Step, *Respons
 }
 
 // Update modifies a step with the provided details.
-// nolint
 func (svc *AdminStepService) Update(s *library.Step) (*library.Step, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/step")
+	u := "/api/v1/admin/step"
 
 	// library Step type we want to return
 	v := new(library.Step)
@@ -310,10 +298,9 @@ func (svc *AdminStepService) Update(s *library.Step) (*library.Step, *Response, 
 }
 
 // GetAll returns a list of all users.
-// nolint
 func (svc *AdminUserService) GetAll(opt *ListOptions) (*[]library.User, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/admin/users")
+	u := "/api/v1/admin/users"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -331,10 +318,9 @@ func (svc *AdminUserService) GetAll(opt *ListOptions) (*[]library.User, *Respons
 }
 
 // Update modifies a user with the provided details.
-// nolint
 func (svc *AdminUserService) Update(u *library.User) (*library.User, *Response, error) {
 	// set the API endpoint path we send the request to
-	url := fmt.Sprintf("/api/v1/admin/user")
+	url := "/api/v1/admin/user"
 
 	// library User type we want to return
 	v := new(library.User)

--- a/vela/authentication.go
+++ b/vela/authentication.go
@@ -39,7 +39,7 @@ func (svc *AuthenticationService) SetTokenAuth(token string) {
 	svc.authType = AuthenticationToken
 }
 
-// SetPersonalAccessTokenAuth sets the authentication type as personal access token
+// SetPersonalAccessTokenAuth sets the authentication type as personal access token.
 func (svc *AuthenticationService) SetPersonalAccessTokenAuth(token string) {
 	svc.personalAccessToken = String(token)
 	svc.authType = PersonalAccessToken

--- a/vela/build.go
+++ b/vela/build.go
@@ -29,6 +29,8 @@ func (svc *BuildService) Get(org, repo string, build int) (*library.Build, *Resp
 }
 
 // GetAll returns a list of all builds.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *BuildService) GetAll(org, repo string, opt *ListOptions) (*[]library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds", org, repo)
@@ -63,6 +65,8 @@ func (svc *BuildService) GetLogs(org, repo string, build int) (*[]library.Log, *
 }
 
 // Add constructs a build with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *BuildService) Add(org, repo string, b *library.Build) (*library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds", org, repo)
@@ -77,6 +81,8 @@ func (svc *BuildService) Add(org, repo string, b *library.Build) (*library.Build
 }
 
 // Update modifies a build with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *BuildService) Update(org, repo string, b *library.Build) (*library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d", org, repo, b.GetNumber())
@@ -104,7 +110,7 @@ func (svc *BuildService) Remove(org, repo string, build int) (*string, *Response
 	return v, resp, err
 }
 
-// Restart takes the build provided and restarts it
+// Restart takes the build provided and restarts it.
 func (svc *BuildService) Restart(org, repo string, build int) (*library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d", org, repo, build)
@@ -118,7 +124,7 @@ func (svc *BuildService) Restart(org, repo string, build int) (*library.Build, *
 	return v, resp, err
 }
 
-// Cancel takes the build provided and cancels it
+// Cancel takes the build provided and cancels it.
 func (svc *BuildService) Cancel(org, repo string, build int) (*library.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/cancel", org, repo, build)

--- a/vela/client.go
+++ b/vela/client.go
@@ -71,15 +71,15 @@ type (
 		PerPage int `url:"per_page,omitempty"`
 	}
 
-	// OAuthExchangeOptions represents the required parameters to exchange
-	// for tokens
+	// OAuthExchangeOptions represents the required
+	// parameters to exchange for tokens.
 	OAuthExchangeOptions struct {
 		Code  string `url:"code,omitempty"`
 		State string `url:"state,omitempty"`
 	}
 
-	// LoginOptions represents the optional parameters to launch
-	// the login process
+	// LoginOptions represents the optional parameters
+	// to launch the login process.
 	LoginOptions struct {
 		Type string `url:"type,omitempty"`
 		Port string `url:"port,omitempty"`

--- a/vela/client_test.go
+++ b/vela/client_test.go
@@ -267,7 +267,7 @@ func TestVela_addAuthentication_AccessAndRefresh_ExpiredTokens(t *testing.T) {
 
 func TestVela_addAuthentication_AccessAndRefresh_ExpiredAccessGoodRefresh(t *testing.T) {
 	// setup types
-	want := fmt.Sprintf("Bearer header.payload.signature")
+	want := "Bearer header.payload.signature"
 
 	s := httptest.NewServer(server.FakeHandler())
 	c, err := NewClient(s.URL, "", nil)
@@ -322,7 +322,7 @@ func TestVela_NewRequest(t *testing.T) {
 	}
 
 	want.Header.Add("Content-Type", "application/json")
-	want.Header.Add("Authorization", fmt.Sprintf("Bearer foobar"))
+	want.Header.Add("Authorization", "Bearer foobar")
 	want.Header.Add("User-Agent", c.UserAgent)
 
 	c.Authentication.SetTokenAuth("foobar")

--- a/vela/deployment.go
+++ b/vela/deployment.go
@@ -15,6 +15,8 @@ import (
 type DeploymentService service
 
 // Get returns the provided deployment.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *DeploymentService) Get(org, repo string, deployment int) (*library.Deployment, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/deployments/%s/%s/%d", org, repo, deployment)
@@ -29,6 +31,8 @@ func (svc *DeploymentService) Get(org, repo string, deployment int) (*library.De
 }
 
 // GetAll returns a list of all deployments.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *DeploymentService) GetAll(org, repo string, opt *ListOptions) (*[]library.Deployment, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/deployments/%s/%s", org, repo)
@@ -49,6 +53,8 @@ func (svc *DeploymentService) GetAll(org, repo string, opt *ListOptions) (*[]lib
 }
 
 // Add constructs a deployment with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *DeploymentService) Add(org, repo string, d *library.Deployment) (*library.Deployment, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/deployments/%s/%s", org, repo)

--- a/vela/hook.go
+++ b/vela/hook.go
@@ -29,6 +29,8 @@ func (svc *HookService) Get(org, repo string, hook int) (*library.Hook, *Respons
 }
 
 // GetAll returns a list of all hooks.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *HookService) GetAll(org, repo string, opt *ListOptions) (*[]library.Hook, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/hooks/%s/%s", org, repo)
@@ -63,6 +65,8 @@ func (svc *HookService) Add(org, repo string, h *library.Hook) (*library.Hook, *
 }
 
 // Update modifies a hook with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *HookService) Update(org, repo string, h *library.Hook) (*library.Hook, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/hooks/%s/%s/%d", org, repo, h.GetNumber())

--- a/vela/log.go
+++ b/vela/log.go
@@ -15,6 +15,8 @@ import (
 type LogService service
 
 // GetService returns the provided service log.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *LogService) GetService(org, repo string, build, service int) (*library.Log, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d/logs", org, repo, build, service)
@@ -29,6 +31,8 @@ func (svc *LogService) GetService(org, repo string, build, service int) (*librar
 }
 
 // AddService constructs a service log with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *LogService) AddService(org, repo string, build, service int, l *library.Log) (*library.Log, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d/logs", org, repo, build, service)
@@ -43,6 +47,8 @@ func (svc *LogService) AddService(org, repo string, build, service int, l *libra
 }
 
 // UpdateService modifies a service log with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *LogService) UpdateService(org, repo string, build, service int, l *library.Log) (*library.Log, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d/logs", org, repo, build, service)
@@ -57,6 +63,8 @@ func (svc *LogService) UpdateService(org, repo string, build, service int, l *li
 }
 
 // RemoveService deletes the provided service log.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *LogService) RemoveService(org, repo string, build, service int) (*string, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d/logs", org, repo, build, service)
@@ -85,6 +93,8 @@ func (svc *LogService) GetStep(org, repo string, build, step int) (*library.Log,
 }
 
 // AddStep constructs a step log with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *LogService) AddStep(org, repo string, build, step int, l *library.Log) (*library.Log, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps/%d/logs", org, repo, build, step)
@@ -99,6 +109,8 @@ func (svc *LogService) AddStep(org, repo string, build, step int, l *library.Log
 }
 
 // UpdateStep modifies a step log with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *LogService) UpdateStep(org, repo string, build, step int, l *library.Log) (*library.Log, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps/%d/logs", org, repo, build, step)

--- a/vela/pipeline.go
+++ b/vela/pipeline.go
@@ -40,6 +40,8 @@ type PipelineOptions struct {
 }
 
 // Get returns the provided pipeline.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *PipelineService) Get(org, repo string, opt *PipelineOptions) (*yaml.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/pipelines/%s/%s", org, repo)
@@ -60,6 +62,8 @@ func (svc *PipelineService) Get(org, repo string, opt *PipelineOptions) (*yaml.B
 }
 
 // Compile returns the provided fully compiled pipeline.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *PipelineService) Compile(org, repo string, opt *PipelineOptions) (*yaml.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/pipelines/%s/%s/compile", org, repo)
@@ -80,6 +84,8 @@ func (svc *PipelineService) Compile(org, repo string, opt *PipelineOptions) (*ya
 }
 
 // Expand returns the provided pipeline fully compiled.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *PipelineService) Expand(org, repo string, opt *PipelineOptions) (*yaml.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/pipelines/%s/%s/expand", org, repo)
@@ -100,6 +106,8 @@ func (svc *PipelineService) Expand(org, repo string, opt *PipelineOptions) (*yam
 }
 
 // Templates returns the provided templates for a pipeline.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *PipelineService) Templates(org, repo string, opt *PipelineOptions) (map[string]*yaml.Template, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/pipelines/%s/%s/templates", org, repo)
@@ -120,6 +128,8 @@ func (svc *PipelineService) Templates(org, repo string, opt *PipelineOptions) (m
 }
 
 // Validate returns the validation status of the provided pipeline.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *PipelineService) Validate(org, repo string, opt *PipelineOptions) (*string, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/pipelines/%s/%s/validate", org, repo)

--- a/vela/repo.go
+++ b/vela/repo.go
@@ -31,7 +31,7 @@ func (svc *RepoService) Get(org, repo string) (*library.Repo, *Response, error) 
 // GetAll returns a list of all repos.
 func (svc *RepoService) GetAll(opt *ListOptions) (*[]library.Repo, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/repos")
+	u := "/api/v1/repos"
 
 	// add optional arguments if supplied
 	u, err := addOptions(u, opt)
@@ -51,7 +51,7 @@ func (svc *RepoService) GetAll(opt *ListOptions) (*[]library.Repo, *Response, er
 // Add constructs a repo with the provided details.
 func (svc *RepoService) Add(r *library.Repo) (*library.Repo, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/repos")
+	u := "/api/v1/repos"
 
 	// library Repo type we want to return
 	v := new(library.Repo)
@@ -63,6 +63,8 @@ func (svc *RepoService) Add(r *library.Repo) (*library.Repo, *Response, error) {
 }
 
 // Update modifies a repo with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *RepoService) Update(org, repo string, r *library.Repo) (*library.Repo, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s", org, repo)

--- a/vela/secret.go
+++ b/vela/secret.go
@@ -15,6 +15,8 @@ import (
 type SecretService service
 
 // Get returns the provided secret.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SecretService) Get(engine, sType, org, name, secret string) (*library.Secret, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/secrets/%s/%s/%s/%s/%s", engine, sType, org, name, secret)
@@ -29,6 +31,8 @@ func (svc *SecretService) Get(engine, sType, org, name, secret string) (*library
 }
 
 // GetAll returns a list of all secrets.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SecretService) GetAll(engine, sType, org, name string, opt *ListOptions) (*[]library.Secret, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/secrets/%s/%s/%s/%s", engine, sType, org, name)
@@ -49,6 +53,8 @@ func (svc *SecretService) GetAll(engine, sType, org, name string, opt *ListOptio
 }
 
 // Add constructs a secret with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SecretService) Add(engine, sType, org, name string, s *library.Secret) (*library.Secret, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/secrets/%s/%s/%s/%s", engine, sType, org, name)
@@ -63,6 +69,8 @@ func (svc *SecretService) Add(engine, sType, org, name string, s *library.Secret
 }
 
 // Update modifies a secret with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SecretService) Update(engine, sType, org, name string, s *library.Secret) (*library.Secret, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/secrets/%s/%s/%s/%s/%s", engine, sType, org, name, s.GetName())
@@ -77,6 +85,8 @@ func (svc *SecretService) Update(engine, sType, org, name string, s *library.Sec
 }
 
 // Remove deletes the provided secret.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SecretService) Remove(engine, sType, org, name, secret string) (*string, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/secrets/%s/%s/%s/%s/%s", engine, sType, org, name, secret)

--- a/vela/service.go
+++ b/vela/service.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore dupl linter false positive
 package vela
 
 import (
@@ -15,6 +16,8 @@ import (
 type SvcService service
 
 // Get returns the provided service.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SvcService) Get(org, repo string, build, service int) (*library.Service, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d", org, repo, build, service)
@@ -29,6 +32,8 @@ func (svc *SvcService) Get(org, repo string, build, service int) (*library.Servi
 }
 
 // GetAll returns a list of all services.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SvcService) GetAll(org, repo string, build int, opt *ListOptions) (*[]library.Service, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services", org, repo, build)
@@ -49,6 +54,8 @@ func (svc *SvcService) GetAll(org, repo string, build int, opt *ListOptions) (*[
 }
 
 // Add constructs a service with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SvcService) Add(org, repo string, build int, s *library.Service) (*library.Service, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services", org, repo, build)
@@ -63,6 +70,8 @@ func (svc *SvcService) Add(org, repo string, build int, s *library.Service) (*li
 }
 
 // Update modifies a service with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *SvcService) Update(org, repo string, build int, s *library.Service) (*library.Service, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d", org, repo, build, s.GetNumber())

--- a/vela/step.go
+++ b/vela/step.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore dupl linter false positive
 package vela
 
 import (
@@ -29,6 +30,8 @@ func (svc *StepService) Get(org, repo string, build, step int) (*library.Step, *
 }
 
 // GetAll returns a list of all steps.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *StepService) GetAll(org, repo string, build int, opt *ListOptions) (*[]library.Step, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps", org, repo, build)
@@ -49,6 +52,8 @@ func (svc *StepService) GetAll(org, repo string, build int, opt *ListOptions) (*
 }
 
 // Add constructs a step with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *StepService) Add(org, repo string, build int, s *library.Step) (*library.Step, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps", org, repo, build)
@@ -63,6 +68,8 @@ func (svc *StepService) Add(org, repo string, build int, s *library.Step) (*libr
 }
 
 // Update modifies a step with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *StepService) Update(org, repo string, build int, s *library.Step) (*library.Step, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps/%d", org, repo, build, s.GetNumber())

--- a/vela/worker.go
+++ b/vela/worker.go
@@ -31,7 +31,7 @@ func (svc *WorkerService) Get(hostname string) (*library.Worker, *Response, erro
 // GetAll returns a list of all workers.
 func (svc *WorkerService) GetAll() (*[]library.Worker, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/workers")
+	u := "/api/v1/workers"
 
 	// slice library Worker type we want to return
 	v := new([]library.Worker)
@@ -45,7 +45,7 @@ func (svc *WorkerService) GetAll() (*[]library.Worker, *Response, error) {
 // Add constructs a worker with the provided details.
 func (svc *WorkerService) Add(w *library.Worker) (*library.Worker, *Response, error) {
 	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/workers")
+	u := "/api/v1/workers"
 
 	// library Worker type we want to return
 	v := new(library.Worker)
@@ -57,6 +57,8 @@ func (svc *WorkerService) Add(w *library.Worker) (*library.Worker, *Response, er
 }
 
 // Update modifies a worker with the provided details.
+//
+// nolint: lll // ignore long line length due to variable names
 func (svc *WorkerService) Update(worker string, w *library.Worker) (*library.Worker, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/workers/%s", worker)


### PR DESCRIPTION
Continuation of the efforts from https://github.com/go-vela/mock/pull/76 and https://github.com/go-vela/types/pull/122

* Updating the contributing guide to include fixing linter warnings if any are present
* Skipping the `dupl` and `lll` linters on `*_test.go` files
* Added `nolint` directives across the repo to address any current linter issues