### PR TITLE
chore: upgrade go-vela deps on v0.8.0-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gin-gonic/gin v1.7.2
-	github.com/go-vela/mock v0.8.0-rc1
-	github.com/go-vela/types v0.8.0-rc1
+	github.com/go-vela/mock v0.8.0-rc2
+	github.com/go-vela/types v0.8.0-rc2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.1.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -41,10 +41,10 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
-github.com/go-vela/mock v0.8.0-rc1 h1:nQHK4rBKYx9h8dKbxrpzr0ysgI83/A24CYgUflXEYwU=
-github.com/go-vela/mock v0.8.0-rc1/go.mod h1:bHEfteKaPwudK9MpzB0qFYuUiYh0l+G7bfgHEW7XAwg=
-github.com/go-vela/types v0.8.0-rc1 h1:jRlrjCKxYuTvqE4StER9Y3sAMqaU5yJoPcl0zM3bLL8=
-github.com/go-vela/types v0.8.0-rc1/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
+github.com/go-vela/mock v0.8.0-rc2 h1:vvYEa2m1NQ9Gsf16PBPEI58w14HRZOdCem6SWQLSRTo=
+github.com/go-vela/mock v0.8.0-rc2/go.mod h1:XVIjXAx6ArvS+HQ2QYCzYgP+YG7w0wZ/MrORCWOM/7k=
+github.com/go-vela/types v0.8.0-rc2 h1:O9YYfdCCuHxPZ9aaXwcp/LNDLnAaHMMqfLkj4LaR69U=
+github.com/go-vela/types v0.8.0-rc2/go.mod h1:tKk+FpEAv+BTMr9CL3Wed6tMy5IqyOCJpRTKZI88yDc=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=


### PR DESCRIPTION
This updates the following dependencies to `v0.8.0-rc2`:

* `github.com/go-vela/mock`
* `github.com/go-vela/types`