### PR TITLE
chore(version): bump version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ var (
 	// VersionMajor is for an API incompatible changes.
 	VersionMajor int64
 	// VersionMinor is for functionality in a backwards-compatible manner.
-	VersionMinor int64 = 10
+	VersionMinor int64 = 11
 	// VersionPatch is for backwards-compatible bug fixes.
 	VersionPatch int64
 )


### PR DESCRIPTION
forgot to bump version in the `version` package 😲 