### PR TITLE
chore(deps): update go to 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.16
+      image: golang:1.17
     steps:
       - name: clone
         uses: actions/checkout@v2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -10,7 +10,7 @@ jobs:
   diff-review:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.16
+      image: golang:1.17
     steps:
     - name: clone
       uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
   full-review:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.16
+      image: golang:1.17
     steps:
     - name: clone
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.16
+      image: golang:1.17
     steps:
     - name: clone
       uses: actions/checkout@v2

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     container:
-      image: golang:1.16
+      image: golang:1.17
     steps:
     - name: clone
       uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-vela/sdk-go
 
-go 1.16
+go 1.17
 
 require (
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
@@ -12,4 +12,24 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.1.0
 	github.com/sirupsen/logrus v1.8.1
+)
+
+require (
+	github.com/drone/envsubst v1.0.3 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.4.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/ugorji/go/codec v1.1.11 // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
Updates Go to 1.17, GitHub Actions pipelines included.

xref: go-vela/types#221