### PR TITLE
fix(build): changing int to int64

### DIFF
--- a/vela/build.go
+++ b/vela/build.go
@@ -20,8 +20,8 @@ type BuildListOptions struct {
 	Branch string `url:"branch,omitempty"`
 	Event  string `url:"event,omitempty"`
 	Status string `url:"status,omitempty"`
-	Before int    `url:"before,omitempty"`
-	After  int    `url:"after,omitempty"`
+	Before int64  `url:"before,omitempty"`
+	After  int64  `url:"after,omitempty"`
 
 	ListOptions
 }


### PR DESCRIPTION
In https://github.com/go-vela/sdk-go/pull/166, I mistakenly declared the `before` and `after` query params as type `int`, rather than type `int64`, which is the correct type.