### PR TITLE
chore: Delete unused `/stream` endpoints

### DIFF
--- a/vela/service.go
+++ b/vela/service.go
@@ -7,7 +7,6 @@ package vela
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/go-vela/types/library"
 )
@@ -90,15 +89,4 @@ func (svc *SvcService) Remove(org, repo string, build, service int) (*string, *R
 	resp, err := svc.client.Call("DELETE", u, nil, v)
 
 	return v, resp, err
-}
-
-// Stream opens a connection to the stream endpoint for the service.
-func (svc *SvcService) Stream(org, repo string, build, service int, rc io.ReadCloser) (*Response, error) {
-	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d/stream", org, repo, build, service)
-
-	// send request using client
-	resp, err := svc.client.CallWithHeaders("POST", u, rc, nil, map[string]string{"Content-Type": "application/octet-stream"})
-
-	return resp, err
 }

--- a/vela/service_test.go
+++ b/vela/service_test.go
@@ -7,7 +7,6 @@ package vela
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -339,36 +338,4 @@ func ExampleSvcService_Remove() {
 	}
 
 	fmt.Printf("Received response code %d, for service %+v", resp.StatusCode, service)
-}
-
-func TestVela_ServiceStream(t *testing.T) {
-	// setup context
-	gin.SetMode(gin.TestMode)
-
-	s := httptest.NewServer(server.FakeHandler())
-	c, _ := NewClient(s.URL, "", nil)
-
-	type input struct {
-		org     string
-		repo    string
-		build   int
-		service int
-		rc      io.ReadCloser
-	}
-
-	tests := []struct {
-		input input
-	}{
-		{
-			input: input{org: "github", repo: "octocat", build: 1, service: 1, rc: nil},
-		},
-	}
-
-	for _, test := range tests {
-		got, _ := c.Svc.Stream(test.input.org, test.input.repo, test.input.build, test.input.service, test.input.rc)
-
-		if got.StatusCode != http.StatusNoContent {
-			t.Errorf("Stream returned %v, want %v", got.StatusCode, http.StatusNoContent)
-		}
-	}
 }

--- a/vela/step.go
+++ b/vela/step.go
@@ -7,7 +7,6 @@ package vela
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/go-vela/types/library"
 )
@@ -90,15 +89,4 @@ func (svc *StepService) Remove(org, repo string, build, step int) (*string, *Res
 	resp, err := svc.client.Call("DELETE", u, nil, v)
 
 	return v, resp, err
-}
-
-// Stream opens a connection to the stream endpoint for the step.
-func (svc *StepService) Stream(org, repo string, build, step int, rc io.ReadCloser) (*Response, error) {
-	// set the API endpoint path we send the request to
-	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps/%d/stream", org, repo, build, step)
-
-	// send request using client
-	resp, err := svc.client.CallWithHeaders("POST", u, rc, nil, map[string]string{"Content-Type": "application/octet-stream"})
-
-	return resp, err
 }

--- a/vela/step_test.go
+++ b/vela/step_test.go
@@ -7,7 +7,6 @@ package vela
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -345,41 +344,4 @@ func ExampleStepService_Remove() {
 	}
 
 	fmt.Printf("Received response code %d, for step %+v", resp.StatusCode, step)
-}
-
-func TestVela_StepStream(t *testing.T) {
-	// setup context
-	gin.SetMode(gin.TestMode)
-
-	s := httptest.NewServer(server.FakeHandler())
-	c, _ := NewClient(s.URL, "", nil)
-
-	type input struct {
-		org   string
-		repo  string
-		build int
-		step  int
-		rc    io.ReadCloser
-	}
-
-	// var buf bytes.Buffer
-
-	tests := []struct {
-		input input
-	}{
-		{
-			input: input{org: "github", repo: "octocat", build: 1, step: 1, rc: nil},
-		},
-		{
-			input: input{org: "github", repo: "octocat", build: 1, step: 1, rc: nil},
-		},
-	}
-
-	for _, test := range tests {
-		got, _ := c.Step.Stream(test.input.org, test.input.repo, test.input.build, test.input.step, test.input.rc)
-
-		if got.StatusCode != http.StatusNoContent {
-			t.Errorf("Stream returned %v, want %v", got.StatusCode, http.StatusNoContent)
-		}
-	}
 }


### PR DESCRIPTION
This is the SDK side of this change: https://github.com/go-vela/server/pull/799