### PR TITLE
fix(register): return error on non-200 response

### DIFF
--- a/vela/admin.go
+++ b/vela/admin.go
@@ -247,8 +247,12 @@ func (svc *AdminWorkerService) Register(workerAddress, registrationToken string)
 
 	// we overwrite the regular success response
 	// because it doesn't make as much sense in this context
-	if resp != nil && resp.StatusCode == http.StatusOK {
-		*v = "worker registered successfully"
+	if resp != nil {
+		if resp.StatusCode == http.StatusOK {
+			*v = "worker registered successfully"
+		} else {
+			err = fmt.Errorf("unable to register worker at %s, received status code %d", workerAddress, resp.StatusCode)
+		}
 	}
 
 	return v, resp, err


### PR DESCRIPTION
solves a use-case where a valid but bogus address is given to the `add worker` command
```
add worker --worker.address https://google.com/ --worker.hostname worker
```