### PR TITLE
chore: delete legacy allow event fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/buildkite/yaml v0.0.0-20230306222819-0e4e032d4835
 	github.com/coreos/go-semver v0.3.1
 	github.com/gin-gonic/gin v1.9.1
-	github.com/go-vela/server v0.23.4-0.20240319161125-1809638e7e72
-	github.com/go-vela/types v0.23.2
+	github.com/go-vela/server v0.23.4-0.20240401175144-f591935d2fc9
+	github.com/go-vela/types v0.23.4-0.20240402153726-f16c3e4cb5fb
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,10 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
-github.com/go-vela/server v0.23.4-0.20240319161125-1809638e7e72 h1:vREnnFuJCKvnYDzHpo8tnXnjpdWgwJ4u2+XB1aoDZQg=
-github.com/go-vela/server v0.23.4-0.20240319161125-1809638e7e72/go.mod h1:uSS5W5UzhNzAsFbKrniwr5OWtq+Q09u/i8H8nr9ls0M=
-github.com/go-vela/types v0.23.2 h1:QDt2lta7FPEfN2RK/Bn++DkqyjGIB4H/Q4XkFAj3hXQ=
-github.com/go-vela/types v0.23.2/go.mod h1:aTE6dzssqTGOvU6m2/vsI9NoSW/3hH/yLzf3cCSo0Zk=
+github.com/go-vela/server v0.23.4-0.20240401175144-f591935d2fc9 h1:R3TxguOk3JsIRoZn0oQBTLZRDIj4Xpeon+L/YJOF2Vw=
+github.com/go-vela/server v0.23.4-0.20240401175144-f591935d2fc9/go.mod h1:Rbe6vgYe3gao8sBcALlhrM2YH4yu2cxJAFpWdDUbdZY=
+github.com/go-vela/types v0.23.4-0.20240402153726-f16c3e4cb5fb h1:jHao/NNRswInMLEb0m1OJ84d1m/LGWMCmaeRqSDnWQY=
+github.com/go-vela/types v0.23.4-0.20240402153726-f16c3e4cb5fb/go.mod h1:mEF9dLkk00rUXf/t39n2WvXZgJbxnPEEWy+DHqIlRUo=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=

--- a/vela/admin_test.go
+++ b/vela/admin_test.go
@@ -15,7 +15,35 @@ import (
 	"github.com/go-vela/server/mock/server"
 	"github.com/go-vela/types"
 	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/library/actions"
 )
+
+func testEvents() *library.Events {
+	return &library.Events{
+		Push: &actions.Push{
+			Branch:       Bool(true),
+			Tag:          Bool(true),
+			DeleteBranch: Bool(true),
+			DeleteTag:    Bool(true),
+		},
+		PullRequest: &actions.Pull{
+			Opened:      Bool(true),
+			Edited:      Bool(true),
+			Synchronize: Bool(true),
+			Reopened:    Bool(true),
+		},
+		Deployment: &actions.Deploy{
+			Created: Bool(true),
+		},
+		Comment: &actions.Comment{
+			Created: Bool(true),
+			Edited:  Bool(true),
+		},
+		Schedule: &actions.Schedule{
+			Run: Bool(true),
+		},
+	}
+}
 
 func TestAdmin_Build_Update_200(t *testing.T) {
 	// setup context
@@ -199,13 +227,33 @@ func TestAdmin_Repo_Update_200(t *testing.T) {
 	_ = json.Unmarshal(data, &want)
 
 	req := library.Repo{
-		Private:     Bool(true),
-		Trusted:     Bool(true),
-		Active:      Bool(true),
-		AllowPull:   Bool(true),
-		AllowPush:   Bool(true),
-		AllowDeploy: Bool(true),
-		AllowTag:    Bool(true),
+		Private: Bool(true),
+		Trusted: Bool(true),
+		Active:  Bool(true),
+		AllowEvents: &library.Events{
+			Push: &actions.Push{
+				Branch:       Bool(true),
+				Tag:          Bool(true),
+				DeleteBranch: Bool(true),
+				DeleteTag:    Bool(true),
+			},
+			PullRequest: &actions.Pull{
+				Opened:      Bool(true),
+				Edited:      Bool(true),
+				Synchronize: Bool(true),
+				Reopened:    Bool(true),
+			},
+			Deployment: &actions.Deploy{
+				Created: Bool(true),
+			},
+			Comment: &actions.Comment{
+				Created: Bool(true),
+				Edited:  Bool(true),
+			},
+			Schedule: &actions.Schedule{
+				Run: Bool(true),
+			},
+		},
 	}
 
 	// run test
@@ -237,10 +285,11 @@ func TestAdmin_Secret_Update_200(t *testing.T) {
 	_ = json.Unmarshal(data, &want)
 
 	req := library.Secret{
-		Name:   String("foo"),
-		Value:  String("bar"),
-		Events: &[]string{"barf", "foob"},
+		Name:        String("foo"),
+		Value:       String("bar"),
+		AllowEvents: testEvents(),
 	}
+
 	// run test
 	got, resp, err := c.Admin.Secret.Update(&req)
 

--- a/vela/admin_test.go
+++ b/vela/admin_test.go
@@ -18,33 +18,6 @@ import (
 	"github.com/go-vela/types/library/actions"
 )
 
-func testEvents() *library.Events {
-	return &library.Events{
-		Push: &actions.Push{
-			Branch:       Bool(true),
-			Tag:          Bool(true),
-			DeleteBranch: Bool(true),
-			DeleteTag:    Bool(true),
-		},
-		PullRequest: &actions.Pull{
-			Opened:      Bool(true),
-			Edited:      Bool(true),
-			Synchronize: Bool(true),
-			Reopened:    Bool(true),
-		},
-		Deployment: &actions.Deploy{
-			Created: Bool(true),
-		},
-		Comment: &actions.Comment{
-			Created: Bool(true),
-			Edited:  Bool(true),
-		},
-		Schedule: &actions.Schedule{
-			Run: Bool(true),
-		},
-	}
-}
-
 func TestAdmin_Build_Update_200(t *testing.T) {
 	// setup context
 	gin.SetMode(gin.TestMode)

--- a/vela/repo_test.go
+++ b/vela/repo_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-vela/server/mock/server"
 	"github.com/go-vela/types/library"
+	"github.com/go-vela/types/library/actions"
 
 	"github.com/gin-gonic/gin"
 )
@@ -450,4 +451,31 @@ func ExampleRepoService_Chown() {
 	}
 
 	fmt.Printf("Received response code %d, for repo %+v", resp.StatusCode, repo)
+}
+
+func testEvents() *library.Events {
+	return &library.Events{
+		Push: &actions.Push{
+			Branch:       Bool(true),
+			Tag:          Bool(true),
+			DeleteBranch: Bool(true),
+			DeleteTag:    Bool(true),
+		},
+		PullRequest: &actions.Pull{
+			Opened:      Bool(true),
+			Edited:      Bool(true),
+			Synchronize: Bool(true),
+			Reopened:    Bool(true),
+		},
+		Deployment: &actions.Deploy{
+			Created: Bool(true),
+		},
+		Comment: &actions.Comment{
+			Created: Bool(true),
+			Edited:  Bool(true),
+		},
+		Schedule: &actions.Schedule{
+			Run: Bool(true),
+		},
+	}
 }

--- a/vela/repo_test.go
+++ b/vela/repo_test.go
@@ -121,10 +121,7 @@ func TestRepo_Add_201(t *testing.T) {
 		Private:     Bool(false),
 		Trusted:     Bool(false),
 		Active:      Bool(true),
-		AllowPull:   Bool(false),
-		AllowPush:   Bool(true),
-		AllowDeploy: Bool(false),
-		AllowTag:    Bool(false),
+		AllowEvents: testEvents(),
 	}
 
 	// run test
@@ -159,10 +156,7 @@ func TestRepo_Update_200(t *testing.T) {
 		Private:     Bool(true),
 		Trusted:     Bool(true),
 		Active:      Bool(true),
-		AllowPull:   Bool(true),
-		AllowPush:   Bool(true),
-		AllowDeploy: Bool(true),
-		AllowTag:    Bool(true),
+		AllowEvents: testEvents(),
 	}
 
 	// run test
@@ -194,10 +188,7 @@ func TestRepo_Update_404(t *testing.T) {
 		Private:     Bool(true),
 		Trusted:     Bool(true),
 		Active:      Bool(true),
-		AllowPull:   Bool(true),
-		AllowPush:   Bool(true),
-		AllowDeploy: Bool(true),
-		AllowTag:    Bool(true),
+		AllowEvents: testEvents(),
 	}
 
 	// run test
@@ -381,10 +372,7 @@ func ExampleRepoService_Add() {
 		Private:     Bool(false),
 		Trusted:     Bool(false),
 		Active:      Bool(true),
-		AllowPull:   Bool(true),
-		AllowPush:   Bool(true),
-		AllowDeploy: Bool(false),
-		AllowTag:    Bool(false),
+		AllowEvents: testEvents(),
 	}
 
 	// Create the repo in the server
@@ -404,8 +392,7 @@ func ExampleRepoService_Update() {
 	c.Authentication.SetPersonalAccessTokenAuth("token")
 
 	req := library.Repo{
-		AllowDeploy: Bool(true),
-		AllowTag:    Bool(true),
+		AllowEvents: testEvents(),
 	}
 
 	// Update the repo in the server

--- a/vela/secret_test.go
+++ b/vela/secret_test.go
@@ -110,12 +110,12 @@ func TestSecret_Add_201(t *testing.T) {
 	_ = json.Unmarshal(data, &want)
 
 	req := library.Secret{
-		Org:    String("github"),
-		Repo:   String("octocat"),
-		Name:   String("foo"),
-		Value:  String("bar"),
-		Images: &[]string{"foo", "bar"},
-		Events: &[]string{"barf", "foob"},
+		Org:         String("github"),
+		Repo:        String("octocat"),
+		Name:        String("foo"),
+		Value:       String("bar"),
+		Images:      &[]string{"foo", "bar"},
+		AllowEvents: testEvents(),
 	}
 
 	// run test
@@ -147,9 +147,9 @@ func TestSecret_Update_200(t *testing.T) {
 	_ = json.Unmarshal(data, &want)
 
 	req := library.Secret{
-		Name:   String("foo"),
-		Value:  String("bar"),
-		Events: &[]string{"barf", "foob"},
+		Name:        String("foo"),
+		Value:       String("bar"),
+		AllowEvents: testEvents(),
 	}
 
 	// run test
@@ -178,9 +178,9 @@ func TestSecret_Update_404(t *testing.T) {
 	want := library.Secret{}
 
 	req := library.Secret{
-		Name:   String("foo"),
-		Value:  String("bar"),
-		Events: &[]string{"barf", "foob"},
+		Name:        String("foo"),
+		Value:       String("bar"),
+		AllowEvents: testEvents(),
 	}
 
 	// run test
@@ -277,10 +277,10 @@ func ExampleSecretService_Add() {
 	c.Authentication.SetPersonalAccessTokenAuth("token")
 
 	req := library.Secret{
-		Name:   String("foo"),
-		Value:  String("bar"),
-		Images: &[]string{"foo", "bar"},
-		Events: &[]string{"foo", "bar"},
+		Name:        String("foo"),
+		Value:       String("bar"),
+		Images:      &[]string{"foo", "bar"},
+		AllowEvents: testEvents(),
 	}
 
 	// Create the secret in the server
@@ -300,9 +300,9 @@ func ExampleSecretService_Update() {
 	c.Authentication.SetPersonalAccessTokenAuth("token")
 
 	req := library.Secret{
-		Name:   String("foo"),
-		Value:  String("bar"),
-		Events: &[]string{"barf", "foob"},
+		Name:        String("foo"),
+		Value:       String("bar"),
+		AllowEvents: testEvents(),
 	}
 
 	// Update the secret in the server


### PR DESCRIPTION
see: https://github.com/go-vela/types/pull/362