### PR TITLE
refactor(schedule): nested API + migration to server types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/buildkite/yaml v0.0.0-20230306222819-0e4e032d4835
 	github.com/coreos/go-semver v0.3.1
 	github.com/gin-gonic/gin v1.9.1
-	github.com/go-vela/server v0.23.4-0.20240424144436-b55aa2bb3684
-	github.com/go-vela/types v0.23.4-0.20240405205548-f24f795ac0b7
+	github.com/go-vela/server v0.23.4-0.20240508133721-300ca456e3bb
+	github.com/go-vela/types v0.23.4-0.20240417135026-fb4a95c30338
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -30,10 +30,10 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-playground/validator/v10 v10.14.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
-github.com/go-vela/server v0.23.4-0.20240424144436-b55aa2bb3684 h1:O0gfupNx7aYPCCrXwVuisrbbqbVkvrRqRBAkSg1bIww=
-github.com/go-vela/server v0.23.4-0.20240424144436-b55aa2bb3684/go.mod h1:QV9JFv+LdpAgkRJhHE92dh4vVdh0kNv8OJnyOLt++84=
-github.com/go-vela/types v0.23.4-0.20240405205548-f24f795ac0b7 h1:3mN7ej69dMH3Vis3G/tPLzLL0Rfp8nR5qd0gpj5ejRM=
-github.com/go-vela/types v0.23.4-0.20240405205548-f24f795ac0b7/go.mod h1:mEF9dLkk00rUXf/t39n2WvXZgJbxnPEEWy+DHqIlRUo=
+github.com/go-vela/server v0.23.4-0.20240508133721-300ca456e3bb h1:nzDitT5zNk5k49n/oEESPwL8xwLWf5iLLJDJkT3Vwik=
+github.com/go-vela/server v0.23.4-0.20240508133721-300ca456e3bb/go.mod h1:2KcNYX+DfNH/aWwu0pu89Gj9+wAm3S70VMy53/LMZjs=
+github.com/go-vela/types v0.23.4-0.20240417135026-fb4a95c30338 h1:I0v47dOdAvjX7lOFN4s28uONChmluD6TNgFL1hpav60=
+github.com/go-vela/types v0.23.4-0.20240417135026-fb4a95c30338/go.mod h1:vISsYDdjz9RPEK6qZ+MxtrdZEjTVU4K30NomB3826u8=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=

--- a/vela/schedule.go
+++ b/vela/schedule.go
@@ -5,19 +5,19 @@ package vela
 import (
 	"fmt"
 
-	"github.com/go-vela/types/library"
+	api "github.com/go-vela/server/api/types"
 )
 
 // ScheduleService handles retrieving schedules from the server methods of the Vela API.
 type ScheduleService service
 
 // Get returns the provided schedule from the repo.
-func (svc *ScheduleService) Get(org, repo, schedule string) (*library.Schedule, *Response, error) {
+func (svc *ScheduleService) Get(org, repo, schedule string) (*api.Schedule, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/schedules/%s/%s/%s", org, repo, schedule)
 
 	// library Schedule type we want to return
-	v := new(library.Schedule)
+	v := new(api.Schedule)
 
 	// send request using client
 	resp, err := svc.client.Call("GET", u, nil, v)
@@ -26,7 +26,7 @@ func (svc *ScheduleService) Get(org, repo, schedule string) (*library.Schedule, 
 }
 
 // GetAll returns a list of all schedules from the repo.
-func (svc *ScheduleService) GetAll(org, repo string, opt *ListOptions) (*[]library.Schedule, *Response, error) {
+func (svc *ScheduleService) GetAll(org, repo string, opt *ListOptions) (*[]api.Schedule, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/schedules/%s/%s", org, repo)
 
@@ -37,7 +37,7 @@ func (svc *ScheduleService) GetAll(org, repo string, opt *ListOptions) (*[]libra
 	}
 
 	// slice library Schedule type we want to return
-	v := new([]library.Schedule)
+	v := new([]api.Schedule)
 
 	// send request using client
 	resp, err := svc.client.Call("GET", u, nil, v)
@@ -46,12 +46,12 @@ func (svc *ScheduleService) GetAll(org, repo string, opt *ListOptions) (*[]libra
 }
 
 // Add constructs a schedule with the provided details.
-func (svc *ScheduleService) Add(org, repo string, s *library.Schedule) (*library.Schedule, *Response, error) {
+func (svc *ScheduleService) Add(org, repo string, s *api.Schedule) (*api.Schedule, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/schedules/%s/%s", org, repo)
 
 	// library Schedule type we want to return
-	v := new(library.Schedule)
+	v := new(api.Schedule)
 
 	// send request using client
 	resp, err := svc.client.Call("POST", u, s, v)
@@ -60,12 +60,12 @@ func (svc *ScheduleService) Add(org, repo string, s *library.Schedule) (*library
 }
 
 // Update modifies a schedule with the provided details.
-func (svc *ScheduleService) Update(org, repo string, s *library.Schedule) (*library.Schedule, *Response, error) {
+func (svc *ScheduleService) Update(org, repo string, s *api.Schedule) (*api.Schedule, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/schedules/%s/%s/%s", org, repo, s.GetName())
 
 	// library Schedule type we want to return
-	v := new(library.Schedule)
+	v := new(api.Schedule)
 
 	// send request using client
 	resp, err := svc.client.Call("PUT", u, s, v)

--- a/vela/schedule_test.go
+++ b/vela/schedule_test.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"testing"
 
+	api "github.com/go-vela/server/api/types"
 	"github.com/go-vela/server/mock/server"
-	"github.com/go-vela/types/library"
 )
 
 func TestSchedule_Get(t *testing.T) {
@@ -21,7 +21,7 @@ func TestSchedule_Get(t *testing.T) {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
-	var schedule library.Schedule
+	var schedule api.Schedule
 	err = json.Unmarshal([]byte(server.ScheduleResp), &schedule)
 	if err != nil {
 		t.Errorf("unable to create test schedule: %v", err)
@@ -36,7 +36,7 @@ func TestSchedule_Get(t *testing.T) {
 		failure  bool
 		name     string
 		args     args
-		want     *library.Schedule
+		want     *api.Schedule
 		wantResp int
 	}{
 		{
@@ -58,7 +58,7 @@ func TestSchedule_Get(t *testing.T) {
 				repo:     "octocat",
 				schedule: "not-found",
 			},
-			want:     new(library.Schedule),
+			want:     new(api.Schedule),
 			wantResp: http.StatusNotFound,
 		},
 	}
@@ -97,7 +97,7 @@ func TestSchedule_GetAll(t *testing.T) {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
-	var schedules []library.Schedule
+	var schedules []api.Schedule
 	err = json.Unmarshal([]byte(server.SchedulesResp), &schedules)
 	if err != nil {
 		t.Errorf("unable to create test schedules: %v", err)
@@ -112,7 +112,7 @@ func TestSchedule_GetAll(t *testing.T) {
 		failure  bool
 		name     string
 		args     args
-		want     []library.Schedule
+		want     []api.Schedule
 		wantResp int
 	}{
 		{
@@ -161,7 +161,7 @@ func TestSchedule_Add(t *testing.T) {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
-	var schedule library.Schedule
+	var schedule api.Schedule
 	err = json.Unmarshal([]byte(server.ScheduleResp), &schedule)
 	if err != nil {
 		t.Errorf("unable to create test schedule: %v", err)
@@ -170,13 +170,13 @@ func TestSchedule_Add(t *testing.T) {
 	type args struct {
 		org      string
 		repo     string
-		schedule *library.Schedule
+		schedule *api.Schedule
 	}
 	tests := []struct {
 		failure  bool
 		name     string
 		args     args
-		want     *library.Schedule
+		want     *api.Schedule
 		wantResp int
 	}{
 		{
@@ -185,7 +185,7 @@ func TestSchedule_Add(t *testing.T) {
 			args: args{
 				org:  "github",
 				repo: "octocat",
-				schedule: &library.Schedule{
+				schedule: &api.Schedule{
 					Active: Bool(true),
 					Name:   String("foo"),
 					Entry:  String("@weekly"),
@@ -229,7 +229,7 @@ func TestSchedule_Update(t *testing.T) {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
-	var schedule library.Schedule
+	var schedule api.Schedule
 	err = json.Unmarshal([]byte(server.ScheduleResp), &schedule)
 	if err != nil {
 		t.Errorf("unable to create test schedule: %v", err)
@@ -238,13 +238,13 @@ func TestSchedule_Update(t *testing.T) {
 	type args struct {
 		org      string
 		repo     string
-		schedule *library.Schedule
+		schedule *api.Schedule
 	}
 	tests := []struct {
 		failure  bool
 		name     string
 		args     args
-		want     *library.Schedule
+		want     *api.Schedule
 		wantResp int
 	}{
 		{
@@ -253,7 +253,7 @@ func TestSchedule_Update(t *testing.T) {
 			args: args{
 				org:  "github",
 				repo: "octocat",
-				schedule: &library.Schedule{
+				schedule: &api.Schedule{
 					Active: Bool(true),
 					Name:   String("foo"),
 					Entry:  String("@weekly"),
@@ -268,11 +268,11 @@ func TestSchedule_Update(t *testing.T) {
 			args: args{
 				org:  "github",
 				repo: "octocat",
-				schedule: &library.Schedule{
+				schedule: &api.Schedule{
 					Name: String("not-found"),
 				},
 			},
-			want:     new(library.Schedule),
+			want:     new(api.Schedule),
 			wantResp: http.StatusNotFound,
 		},
 	}
@@ -420,7 +420,7 @@ func ExampleScheduleService_Add() {
 	// set new token in existing client
 	c.Authentication.SetPersonalAccessTokenAuth("token")
 
-	req := library.Schedule{
+	req := api.Schedule{
 		Active: Bool(true),
 		Name:   String("nightly"),
 		Entry:  String("0 0 * * *"),
@@ -445,7 +445,7 @@ func ExampleScheduleService_Update() {
 	// set new token in existing client
 	c.Authentication.SetPersonalAccessTokenAuth("token")
 
-	req := library.Schedule{
+	req := api.Schedule{
 		Active: Bool(false),
 		Name:   String("nightly"),
 		Entry:  String("0 0 * * *"),


### PR DESCRIPTION
### Description
Moved `Schedule` out of `go-vela/types` and into `go-vela/server`. Updated imports in CLI to reflect those changes.

### Related
https://github.com/go-vela/server/pull/1108