### PR TITLE
chore: use proper int sizing based on server

### DIFF
--- a/vela/build.go
+++ b/vela/build.go
@@ -39,7 +39,7 @@ type IDTokenOptions struct {
 }
 
 // Get returns the provided build.
-func (svc *BuildService) Get(org, repo string, build int) (*api.Build, *Response, error) {
+func (svc *BuildService) Get(org, repo string, build int64) (*api.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d", org, repo, build)
 
@@ -87,7 +87,7 @@ func (svc *BuildService) GetAll(org, repo string, opt *BuildListOptions) (*[]api
 }
 
 // GetLogs returns the provided build logs.
-func (svc *BuildService) GetLogs(org, repo string, build int, opt *ListOptions) (*[]api.Log, *Response, error) {
+func (svc *BuildService) GetLogs(org, repo string, build int64, opt *ListOptions) (*[]api.Log, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/logs", org, repo, build)
 
@@ -149,7 +149,7 @@ func (svc *BuildService) Remove(org, repo string, build int) (*string, *Response
 }
 
 // Restart takes the build provided and restarts it.
-func (svc *BuildService) Restart(org, repo string, build int) (*api.Build, *Response, error) {
+func (svc *BuildService) Restart(org, repo string, build int64) (*api.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d", org, repo, build)
 
@@ -163,7 +163,7 @@ func (svc *BuildService) Restart(org, repo string, build int) (*api.Build, *Resp
 }
 
 // Cancel takes the build provided and cancels it.
-func (svc *BuildService) Cancel(org, repo string, build int) (*api.Build, *Response, error) {
+func (svc *BuildService) Cancel(org, repo string, build int64) (*api.Build, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/cancel", org, repo, build)
 
@@ -177,7 +177,7 @@ func (svc *BuildService) Cancel(org, repo string, build int) (*api.Build, *Respo
 }
 
 // Approve takes the build provided and approves it as an admin.
-func (svc *BuildService) Approve(org, repo string, build int) (*Response, error) {
+func (svc *BuildService) Approve(org, repo string, build int64) (*Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/approve", org, repo, build)
 

--- a/vela/deployment.go
+++ b/vela/deployment.go
@@ -13,7 +13,7 @@ import (
 type DeploymentService service
 
 // Get returns the provided deployment.
-func (svc *DeploymentService) Get(org, repo string, deployment int) (*api.Deployment, *Response, error) {
+func (svc *DeploymentService) Get(org, repo string, deployment int64) (*api.Deployment, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/deployments/%s/%s/%d", org, repo, deployment)
 

--- a/vela/hook.go
+++ b/vela/hook.go
@@ -13,7 +13,7 @@ import (
 type HookService service
 
 // Get returns the provided hook.
-func (svc *HookService) Get(org, repo string, hook int) (*api.Hook, *Response, error) {
+func (svc *HookService) Get(org, repo string, hook int64) (*api.Hook, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/hooks/%s/%s/%d", org, repo, hook)
 
@@ -75,7 +75,7 @@ func (svc *HookService) Update(org, repo string, h *api.Hook) (*api.Hook, *Respo
 }
 
 // Remove deletes the provided hook.
-func (svc *HookService) Remove(org, repo string, hook int) (*string, *Response, error) {
+func (svc *HookService) Remove(org, repo string, hook int64) (*string, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/hooks/%s/%s/%d", org, repo, hook)
 

--- a/vela/service.go
+++ b/vela/service.go
@@ -14,7 +14,7 @@ import (
 type SvcService service
 
 // Get returns the provided service.
-func (svc *SvcService) Get(org, repo string, build, service int) (*api.Service, *Response, error) {
+func (svc *SvcService) Get(org, repo string, build int64, service int32) (*api.Service, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services/%d", org, repo, build, service)
 
@@ -28,7 +28,7 @@ func (svc *SvcService) Get(org, repo string, build, service int) (*api.Service, 
 }
 
 // GetAll returns a list of all services.
-func (svc *SvcService) GetAll(org, repo string, build int, opt *ListOptions) (*[]api.Service, *Response, error) {
+func (svc *SvcService) GetAll(org, repo string, build int64, opt *ListOptions) (*[]api.Service, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/services", org, repo, build)
 

--- a/vela/step.go
+++ b/vela/step.go
@@ -14,7 +14,7 @@ import (
 type StepService service
 
 // Get returns the provided step.
-func (svc *StepService) Get(org, repo string, build, step int) (*api.Step, *Response, error) {
+func (svc *StepService) Get(org, repo string, build int64, step int32) (*api.Step, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps/%d", org, repo, build, step)
 
@@ -28,7 +28,7 @@ func (svc *StepService) Get(org, repo string, build, step int) (*api.Step, *Resp
 }
 
 // GetAll returns a list of all steps.
-func (svc *StepService) GetAll(org, repo string, build int, opt *ListOptions) (*[]api.Step, *Response, error) {
+func (svc *StepService) GetAll(org, repo string, build int64, opt *ListOptions) (*[]api.Step, *Response, error) {
 	// set the API endpoint path we send the request to
 	u := fmt.Sprintf("/api/v1/repos/%s/%s/builds/%d/steps", org, repo, build)
 


### PR DESCRIPTION
A few resource fields became explicit in sizing (`int` -> `int64`)