### PR TITLE
enhance(auth): add build token auth for multiple token headers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
     - unparam
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     dupl:
       threshold: 100
@@ -51,6 +51,10 @@ linters:
       require-explanation: true
       require-specific: true
       allow-unused: false
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2 
   exclusions:
     generated: lax
     presets:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	github.com/coreos/go-semver v0.3.1
 	github.com/gin-gonic/gin v1.10.1
-	github.com/go-vela/server v0.27.0
+	github.com/go-vela/server v0.27.1-0.20250818162730-1fd92adf65b3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc/iMaVtFbr3Sw2k=
 github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
-github.com/go-vela/server v0.27.0 h1:QUcThEP67UnLvf4YPp7dOPQgRL9MgYI2xYjGops4B5g=
-github.com/go-vela/server v0.27.0/go.mod h1:Zlqc4UMaURd1NWTaMy1uw98lKwj2HrCp6BswnL8fpKI=
+github.com/go-vela/server v0.27.1-0.20250818162730-1fd92adf65b3 h1:KXZ8VNdSevGdE/fu543JZSsdb7gCrCWHv27PI0n2uBo=
+github.com/go-vela/server v0.27.1-0.20250818162730-1fd92adf65b3/go.mod h1:Zlqc4UMaURd1NWTaMy1uw98lKwj2HrCp6BswnL8fpKI=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=

--- a/vela/admin_test.go
+++ b/vela/admin_test.go
@@ -28,6 +28,7 @@ func TestAdmin_Build_Update_200(t *testing.T) {
 	data := []byte(server.BuildResp)
 
 	var want api.Build
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Build{
@@ -39,7 +40,6 @@ func TestAdmin_Build_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Build.Update(&req)
-
 	if err != nil {
 		t.Errorf("Build returned err: %v", err)
 	}
@@ -68,7 +68,6 @@ func TestAdmin_Clean_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Clean.Clean(&req, nil)
-
 	if err != nil {
 		t.Errorf("Clean returned err: %v", err)
 	}
@@ -125,6 +124,7 @@ func TestAdmin_Deployment_Update_200(t *testing.T) {
 	data := []byte(server.DeploymentResp)
 
 	var want api.Deployment
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Deployment{
@@ -137,7 +137,6 @@ func TestAdmin_Deployment_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Deployment.Update(&req)
-
 	if err != nil {
 		t.Errorf("Deployment returned err: %v", err)
 	}
@@ -161,6 +160,7 @@ func TestAdmin_Hook_Update_200(t *testing.T) {
 	data := []byte(server.HookResp)
 
 	var want api.Hook
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Hook{
@@ -171,7 +171,6 @@ func TestAdmin_Hook_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Hook.Update(&req)
-
 	if err != nil {
 		t.Errorf("Hook returned err: %v", err)
 	}
@@ -195,6 +194,7 @@ func TestAdmin_Repo_Update_200(t *testing.T) {
 	data := []byte(server.RepoResp)
 
 	var want api.Repo
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Repo{
@@ -229,7 +229,6 @@ func TestAdmin_Repo_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Repo.Update(&req)
-
 	if err != nil {
 		t.Errorf("Repo returned err: %v", err)
 	}
@@ -253,6 +252,7 @@ func TestAdmin_Secret_Update_200(t *testing.T) {
 	data := []byte(server.SecretResp)
 
 	var want api.Secret
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Secret{
@@ -263,7 +263,6 @@ func TestAdmin_Secret_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Secret.Update(&req)
-
 	if err != nil {
 		t.Errorf("Secret returned err: %v", err)
 	}
@@ -287,6 +286,7 @@ func TestAdmin_Service_Update_200(t *testing.T) {
 	data := []byte(server.ServiceResp)
 
 	var want api.Service
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Service{
@@ -298,7 +298,6 @@ func TestAdmin_Service_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Service.Update(&req)
-
 	if err != nil {
 		t.Errorf("Service returned err: %v", err)
 	}
@@ -322,6 +321,7 @@ func TestAdmin_Step_Update_200(t *testing.T) {
 	data := []byte(server.StepResp)
 
 	var want api.Step
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Step{
@@ -333,7 +333,6 @@ func TestAdmin_Step_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.Step.Update(&req)
-
 	if err != nil {
 		t.Errorf("Step returned err: %v", err)
 	}
@@ -357,6 +356,7 @@ func TestAdmin_User_Update_200(t *testing.T) {
 	data := []byte(server.UserResp)
 
 	var want api.User
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.User{
@@ -365,7 +365,6 @@ func TestAdmin_User_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Admin.User.Update(&req)
-
 	if err != nil {
 		t.Errorf("User returned err: %v", err)
 	}
@@ -501,13 +500,13 @@ func TestAdmin_Settings_Update_200(t *testing.T) {
 	data := []byte(server.UpdateSettingsResp)
 
 	var want settings.Platform
+
 	_ = json.Unmarshal(data, &want)
 
 	req := settings.Platform{}
 
 	// run test
 	got, resp, err := c.Admin.Settings.Update(&req)
-
 	if err != nil {
 		t.Errorf("Settings.Update returned err: %v", err)
 	}
@@ -531,11 +530,11 @@ func TestAdmin_Settings_Restore_200(t *testing.T) {
 	data := []byte(server.RestoreSettingsResp)
 
 	var want settings.Platform
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Admin.Settings.Restore()
-
 	if err != nil {
 		t.Errorf("Settings.Restore returned err: %v", err)
 	}

--- a/vela/authentication.go
+++ b/vela/authentication.go
@@ -20,6 +20,7 @@ const (
 	AuthenticationToken AuthenticationType = iota + 1
 	PersonalAccessToken
 	AccessAndRefreshToken
+	BuildToken
 )
 
 // AuthenticationService contains
@@ -30,6 +31,7 @@ type AuthenticationService struct {
 	personalAccessToken *string
 	accessToken         *string
 	refreshToken        *string
+	scmToken            *string
 	authType            AuthenticationType
 }
 
@@ -37,6 +39,13 @@ type AuthenticationService struct {
 func (svc *AuthenticationService) SetTokenAuth(token string) {
 	svc.token = String(token)
 	svc.authType = AuthenticationToken
+}
+
+// SetBuildTokenAuth sets the authentication type and the two tokens used.
+func (svc *AuthenticationService) SetBuildTokenAuth(buildTkn, scmTkn string) {
+	svc.token = String(buildTkn)
+	svc.scmToken = String(scmTkn)
+	svc.authType = BuildToken
 }
 
 // SetPersonalAccessTokenAuth sets the authentication type as personal access token.
@@ -60,6 +69,11 @@ func (svc *AuthenticationService) HasAuth() bool {
 // HasTokenAuth checks if the authentication type is a plain token.
 func (svc *AuthenticationService) HasTokenAuth() bool {
 	return svc.authType == AuthenticationToken
+}
+
+// HasBuildTokenAuth checks if the authentication type is a build and scm token.
+func (svc *AuthenticationService) HasBuildTokenAuth() bool {
+	return svc.authType == BuildToken
 }
 
 // HasPersonalAccessTokenAuth checks if the authentication type is a personal access token.

--- a/vela/authentication_test.go
+++ b/vela/authentication_test.go
@@ -30,6 +30,21 @@ func TestVela_Authentication_SetTokenAuth(t *testing.T) {
 	}
 }
 
+func TestVela_Authentication_SetBuildTokenAuth(t *testing.T) {
+	// setup types
+	c, _ := NewClient("http://localhost:8080", "", nil)
+
+	c.Authentication.SetBuildTokenAuth("buildToken", "scmToken")
+
+	if !c.Authentication.HasAuth() {
+		t.Errorf("SetBuildTokenAuth did not set an authentication type")
+	}
+
+	if !c.Authentication.HasBuildTokenAuth() {
+		t.Errorf("SetBuildTokenAuth did not set BuildToken type")
+	}
+}
+
 func TestVela_Authentication_SetAccessAndRefreshAuth(t *testing.T) {
 	// setup types
 	c, _ := NewClient("http://localhost:8080", "", nil)
@@ -136,11 +151,11 @@ func TestVela_Authentication_RefreshAccessToken(t *testing.T) {
 	data := []byte(server.TokenRefreshResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	resp, err := c.Authentication.RefreshAccessToken("refreshToken")
-
 	if err != nil {
 		t.Errorf("RefreshAccessToken returned err: %v", err)
 	}
@@ -164,11 +179,11 @@ func TestVela_Authentication_AuthenticateWithToken(t *testing.T) {
 	data := []byte(server.TokenRefreshResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	at, resp, err := c.Authentication.AuthenticateWithToken("personalaccesstoken")
-
 	if err != nil {
 		t.Errorf("AuthenticateWithToken returned err: %v", err)
 	}
@@ -191,7 +206,6 @@ func TestVela_Authentication_AuthenticateWithToken_NoToken(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Authentication.AuthenticateWithToken("")
-
 	if err == nil {
 		t.Errorf("AuthenticateWithToken should have returned error")
 	}
@@ -215,6 +229,7 @@ func TestVela_Authentication_ExchangeTokens(t *testing.T) {
 	data := []byte(server.TokenRefreshResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	// create options
@@ -228,7 +243,6 @@ func TestVela_Authentication_ExchangeTokens(t *testing.T) {
 
 	// run test
 	at, rt, resp, err := c.Authentication.ExchangeTokens(opt)
-
 	if err != nil {
 		t.Errorf("ExchangeTokens returned err: %v", err)
 	}
@@ -266,7 +280,6 @@ func TestVela_Authentication_ExchangeTokens_BadInput(t *testing.T) {
 
 	// run test
 	_, _, resp, err := c.Authentication.ExchangeTokens(opt)
-
 	if err == nil {
 		t.Errorf("ExchangeTokens should have returned error: %v", err)
 	}
@@ -295,7 +308,6 @@ func TestVela_Authentication_ValidateToken_200(t *testing.T) {
 
 	// run test
 	resp, err := c.Authentication.ValidateToken()
-
 	if err != nil {
 		t.Errorf("ValidateToken returned error %v", err)
 	}
@@ -316,7 +328,6 @@ func TestVela_Authentication_ValidateToken_NoToken(t *testing.T) {
 
 	// run test
 	resp, err := c.Authentication.ValidateToken()
-
 	if err == nil {
 		t.Error("ValidateToken should have returned error")
 	}
@@ -337,7 +348,6 @@ func TestVela_Authentication_ValidateOAuthToken_200(t *testing.T) {
 
 	// run test
 	resp, err := c.Authentication.ValidateOAuthToken()
-
 	if err != nil {
 		t.Errorf("ValidateOAuthToken returned error %v", err)
 	}
@@ -358,7 +368,6 @@ func TestVela_Authentication_ValidateOAuthToken_NoToken(t *testing.T) {
 
 	// run test
 	resp, err := c.Authentication.ValidateOAuthToken()
-
 	if err == nil {
 		t.Error("ValidateOAuthToken should have returned error")
 	}

--- a/vela/build_test.go
+++ b/vela/build_test.go
@@ -27,11 +27,11 @@ func TestBuild_Get_200(t *testing.T) {
 	data := []byte(server.BuildResp)
 
 	var want api.Build
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.Get("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -56,7 +56,6 @@ func TestBuild_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.Get("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -80,11 +79,11 @@ func TestBuildExecutable_Get_200(t *testing.T) {
 	data := []byte(server.BuildExecutableResp)
 
 	var want api.BuildExecutable
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.GetBuildExecutable("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -109,7 +108,6 @@ func TestBuildExecutable_Get_500(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.GetBuildExecutable("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -133,11 +131,11 @@ func TestBuild_GetAll_200(t *testing.T) {
 	data := []byte(server.BuildsResp)
 
 	var want []api.Build
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.GetAll("github", "octocat", nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -161,11 +159,11 @@ func TestBuild_GetLogs_200(t *testing.T) {
 	data := []byte(server.BuildLogsResp)
 
 	var want []api.Log
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.GetLogs("github", "octocat", 1, nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -190,7 +188,6 @@ func TestBuild_GetLogs_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.GetLogs("github", "octocat", 0, nil)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -214,6 +211,7 @@ func TestBuild_Add_201(t *testing.T) {
 	data := []byte(server.BuildResp)
 
 	var want api.Build
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Build{
@@ -250,7 +248,6 @@ func TestBuild_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.Add(&req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -274,6 +271,7 @@ func TestBuild_Update_200(t *testing.T) {
 	data := []byte(server.BuildResp)
 
 	var want api.Build
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Build{
@@ -289,7 +287,6 @@ func TestBuild_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.Update(&req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -325,7 +322,6 @@ func TestBuild_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.Update(&req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -348,7 +344,6 @@ func TestBuild_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Build.Remove("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -367,7 +362,6 @@ func TestBuild_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Build.Remove("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -387,11 +381,11 @@ func TestBuild_Restart_200(t *testing.T) {
 	data := []byte(server.BuildResp)
 
 	var want api.Build
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.Restart("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -416,7 +410,6 @@ func TestBuild_Restart_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.Restart("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -439,7 +432,6 @@ func TestBuild_Cancel_200(t *testing.T) {
 
 	// run test
 	_, got, err := c.Build.Cancel("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -458,7 +450,6 @@ func TestBuild_Cancel_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Build.Cancel("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -477,7 +468,6 @@ func TestBuild_Approve_200(t *testing.T) {
 
 	// run test
 	got, err := c.Build.Approve("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -496,7 +486,6 @@ func TestBuild_Approve_403(t *testing.T) {
 
 	// run test
 	resp, err := c.Build.Approve("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -516,11 +505,11 @@ func TestBuild_GetBuildToken_200(t *testing.T) {
 	data := []byte(server.BuildTokenResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.GetBuildToken("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("GetBuildToken returned err: %v", err)
 	}
@@ -545,7 +534,6 @@ func TestBuild_GetBuildToken_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.GetBuildToken("github", "octocat", 0)
-
 	if err != nil {
 		t.Errorf("GetBuildToken returned err: %v", err)
 	}
@@ -570,7 +558,6 @@ func TestBuild_GetBuildToken_400(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.GetBuildToken("github", "octocat", 2)
-
 	if err != nil {
 		t.Errorf("GetBuildToken returned err: %v", err)
 	}
@@ -594,11 +581,11 @@ func TestBuild_GetIDRequestToken_200(t *testing.T) {
 	data := []byte(server.IDTokenRequestTokenResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.GetIDRequestToken("github", "octocat", 1, nil)
-
 	if err != nil {
 		t.Errorf("GetIDRequestToken returned err: %v", err)
 	}
@@ -623,7 +610,6 @@ func TestBuild_GetIDRequestToken_400(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.GetIDRequestToken("github", "octocat", 0, nil)
-
 	if err != nil {
 		t.Errorf("GetIDRequestToken returned err: %v", err)
 	}
@@ -647,11 +633,11 @@ func TestBuild_GetIDToken_200(t *testing.T) {
 	data := []byte(server.IDTokenResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Build.GetIDToken("github", "octocat", 1, nil)
-
 	if err != nil {
 		t.Errorf("GetIDToken returned err: %v", err)
 	}
@@ -676,7 +662,6 @@ func TestBuild_GetIDToken_400(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Build.GetIDToken("github", "octocat", 0, nil)
-
 	if err != nil {
 		t.Errorf("GetIDToken returned err: %v", err)
 	}

--- a/vela/client.go
+++ b/vela/client.go
@@ -240,6 +240,17 @@ func (c *Client) addAuthentication(req *http.Request) error {
 		token = *c.Authentication.token
 	}
 
+	if c.Authentication.HasBuildTokenAuth() {
+		token = *c.Authentication.token
+
+		scmTkn := *c.Authentication.scmToken
+		if len(scmTkn) == 0 {
+			return fmt.Errorf("scm token has no value")
+		}
+
+		req.Header.Add("Token", *c.Authentication.scmToken)
+	}
+
 	// make sure token is not empty
 	if len(token) == 0 {
 		return fmt.Errorf("token has no value")

--- a/vela/client_test.go
+++ b/vela/client_test.go
@@ -260,6 +260,41 @@ func TestVela_addAuthentication(t *testing.T) {
 	}
 }
 
+func TestVela_addAuthentication_BuildToken(t *testing.T) {
+	// setup types
+	wantBuild := "Bearer foobar"
+	wantScm := "baz"
+
+	c, err := NewClient("http://localhost:8080", "", nil)
+	if err != nil {
+		t.Errorf("Unable to create new client: %v", err)
+	}
+
+	r, err := http.NewRequestWithContext(context.Background(), "GET", "http://localhost:8080/health", nil)
+	if err != nil {
+		t.Errorf("Unable to create new request: %v", err)
+	}
+
+	// run test
+	c.Authentication.SetBuildTokenAuth("foobar", "baz")
+
+	err = c.addAuthentication(r)
+	if err != nil {
+		t.Error("addAuthentication should not have errored")
+	}
+
+	gotBuild := r.Header.Get("Authorization")
+	gotScm := r.Header.Get("Token")
+
+	if gotBuild != wantBuild {
+		t.Errorf("addAuthentication BuildToken is %v, want %v", gotBuild, wantBuild)
+	}
+
+	if gotScm != wantScm {
+		t.Errorf("addAuthentication SCM Token is %v, want %v", gotScm, wantScm)
+	}
+}
+
 func TestVela_addAuthentication_AccessAndRefresh_GoodToken(t *testing.T) {
 	// setup types
 	testToken := TestTokenGood
@@ -473,9 +508,11 @@ func TestVela_NewRequest(t *testing.T) {
 						test.input.body.(io.ReadCloser),
 					)
 				}
+
 				if err != nil {
 					t.Errorf("Unable to create new request: %v", err)
 				}
+
 				test.want.Header.Add("Content-Type", "application/json")
 				test.want.Header.Add("Authorization", "Bearer foobar")
 				test.want.Header.Add("User-Agent", c.UserAgent)

--- a/vela/dashboard_test.go
+++ b/vela/dashboard_test.go
@@ -25,6 +25,7 @@ func TestDashboard_Get_200(t *testing.T) {
 	data := []byte(server.DashCardResp)
 
 	var want api.DashCard
+
 	err := json.Unmarshal(data, &want)
 	if err != nil {
 		t.Errorf("unable to unmarshal data: %v", err)
@@ -32,7 +33,6 @@ func TestDashboard_Get_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Dashboard.Get("c976470d-34c1-49b2-9a98-1035871c576b")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -57,7 +57,6 @@ func TestDashboard_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Dashboard.Get("0")
-
 	if err == nil {
 		t.Errorf("Get returned err: %v", err)
 	}
@@ -81,11 +80,11 @@ func TestDashboard_GetAllUser_200(t *testing.T) {
 	data := []byte(server.DashCardsResp)
 
 	var want []api.DashCard
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Dashboard.GetAllUser()
-
 	if err != nil {
 		t.Errorf("GetAllUser returned err: %v", err)
 	}
@@ -109,11 +108,11 @@ func TestDashboard_Add_201(t *testing.T) {
 	data := []byte(server.DashboardResp)
 
 	var want api.Dashboard
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Dashboard.Add(&want)
-
 	if err != nil {
 		t.Errorf("Add returned err: %v", err)
 	}
@@ -137,11 +136,11 @@ func TestDashboard_Update_200(t *testing.T) {
 	data := []byte(server.DashboardResp)
 
 	var want api.Dashboard
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Dashboard.Update(&want)
-
 	if err != nil {
 		t.Errorf("Update returned err: %v", err)
 	}

--- a/vela/deployment_test.go
+++ b/vela/deployment_test.go
@@ -27,11 +27,11 @@ func TestDeployment_Get_200(t *testing.T) {
 	data := []byte(server.DeploymentResp)
 
 	var want api.Deployment
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Deployment.Get("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -56,7 +56,6 @@ func TestDeployment_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Deployment.Get("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -80,11 +79,11 @@ func TestDeployment_GetAll_200(t *testing.T) {
 	data := []byte(server.DeploymentsResp)
 
 	var want []api.Deployment
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Deployment.GetAll("github", "octocat", nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -108,6 +107,7 @@ func TestDeployment_Add_201(t *testing.T) {
 	data := []byte(server.DeploymentResp)
 
 	var want api.Deployment
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Deployment{
@@ -120,7 +120,6 @@ func TestDeployment_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Deployment.Add("github", "octocat", &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/hook_test.go
+++ b/vela/hook_test.go
@@ -26,11 +26,11 @@ func TestHook_Get_200(t *testing.T) {
 	data := []byte(server.HookResp)
 
 	var want api.Hook
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Hook.Get("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -55,7 +55,6 @@ func TestHook_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Hook.Get("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -79,11 +78,11 @@ func TestHook_GetAll_200(t *testing.T) {
 	data := []byte(server.HooksResp)
 
 	var want []api.Hook
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Hook.GetAll("github", "octocat", nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -107,6 +106,7 @@ func TestHook_Add_201(t *testing.T) {
 	data := []byte(server.HookResp)
 
 	var want api.Hook
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Hook{
@@ -123,7 +123,6 @@ func TestHook_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Hook.Add("github", "octocat", &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -147,6 +146,7 @@ func TestHook_Update_200(t *testing.T) {
 	data := []byte(server.HookResp)
 
 	var want api.Hook
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Hook{
@@ -157,7 +157,6 @@ func TestHook_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Hook.Update("github", "octocat", &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -188,7 +187,6 @@ func TestHook_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Hook.Update("github", "octocat", &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -211,7 +209,6 @@ func TestHook_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Hook.Remove("github", "octocat", 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -230,7 +227,6 @@ func TestHook_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Hook.Remove("github", "octocat", 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/jwt_test.go
+++ b/vela/jwt_test.go
@@ -80,7 +80,6 @@ func makeSampleToken(c jwt.Claims) string {
 
 	// get the signing string (header + claims)
 	s, e := t.SigningString()
-
 	if e != nil {
 		return ""
 	}

--- a/vela/log_test.go
+++ b/vela/log_test.go
@@ -26,11 +26,11 @@ func TestLog_GetService_200(t *testing.T) {
 	data := []byte(server.LogResp)
 
 	var want api.Log
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Log.GetService("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -55,7 +55,6 @@ func TestLog_GetService_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Log.GetService("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -79,6 +78,7 @@ func TestLog_AddService_201(t *testing.T) {
 	data := []byte(server.LogResp)
 
 	var want api.Log
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Log{
@@ -87,7 +87,6 @@ func TestLog_AddService_201(t *testing.T) {
 
 	// run test
 	resp, err := c.Log.AddService("github", "octocat", 1, 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -110,7 +109,6 @@ func TestLog_UpdateService_200(t *testing.T) {
 
 	// run test
 	resp, err := c.Log.UpdateService("github", "octocat", 1, 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -133,7 +131,6 @@ func TestLog_UpdateService_404(t *testing.T) {
 
 	// run test
 	resp, err := c.Log.UpdateService("github", "not-found", 1, 0, &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -152,7 +149,6 @@ func TestLog_RemoveService_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Log.RemoveService("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -171,7 +167,6 @@ func TestLog_RemoveService_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Log.RemoveService("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -191,11 +186,11 @@ func TestLog_GetStep_200(t *testing.T) {
 	data := []byte(server.LogResp)
 
 	var want api.Log
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Log.GetStep("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -220,7 +215,6 @@ func TestLog_GetStep_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Log.GetStep("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -244,6 +238,7 @@ func TestLog_AddStep_201(t *testing.T) {
 	data := []byte(server.LogResp)
 
 	var want api.Log
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Log{
@@ -252,7 +247,6 @@ func TestLog_AddStep_201(t *testing.T) {
 
 	// run test
 	resp, err := c.Log.AddStep("github", "octocat", 1, 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -275,7 +269,6 @@ func TestLog_UpdateStep_200(t *testing.T) {
 
 	// run test
 	resp, err := c.Log.UpdateStep("github", "octocat", 1, 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -298,7 +291,6 @@ func TestLog_UpdateStep_404(t *testing.T) {
 
 	// run test
 	resp, err := c.Log.UpdateStep("github", "not-found", 1, 0, &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -317,7 +309,6 @@ func TestLog_RemoveStep_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Log.RemoveStep("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -336,7 +327,6 @@ func TestLog_RemoveStep_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Log.RemoveStep("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/login_test.go
+++ b/vela/login_test.go
@@ -63,11 +63,13 @@ func TestAuthorizationService_GetLoginURL(t *testing.T) {
 			svc := &AuthorizationService{
 				client: tt.fields.client,
 			}
+
 			got, err := svc.GetLoginURL(tt.args.opt)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AuthorizationService.GetLoginURL() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("AuthorizationService.GetLoginURL() = %v, want %v", got, tt.want)
 			}

--- a/vela/pipeline_test.go
+++ b/vela/pipeline_test.go
@@ -28,6 +28,7 @@ func TestPipeline_Get_200(t *testing.T) {
 	data := []byte(server.PipelineResp)
 
 	var want api.Pipeline
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
@@ -56,7 +57,6 @@ func TestPipeline_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Pipeline.Get("github", "octocat", "0")
-
 	if err == nil {
 		t.Errorf("Get returned err: %v", err)
 	}
@@ -80,6 +80,7 @@ func TestPipeline_GetAll_200(t *testing.T) {
 	data := []byte(server.PipelinesResp)
 
 	var want []api.Pipeline
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
@@ -107,6 +108,7 @@ func TestPipeline_Add_201(t *testing.T) {
 	data := []byte(server.PipelineResp)
 
 	var want api.Pipeline
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Pipeline{
@@ -142,6 +144,7 @@ func TestPipeline_Update_200(t *testing.T) {
 	data := []byte(server.PipelineResp)
 
 	var want api.Pipeline
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Pipeline{
@@ -179,7 +182,6 @@ func TestPipeline_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Pipeline.Update("github", "octocat", &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -220,7 +222,6 @@ func TestPipeline_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Pipeline.Remove("github", "octocat", "0")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -240,6 +241,7 @@ func TestPipeline_Compile_200(t *testing.T) {
 	data := []byte(server.CompileResp)
 
 	var want yaml.Build
+
 	_ = yml.Unmarshal(data, &want)
 
 	// run test
@@ -268,7 +270,6 @@ func TestPipeline_Compile_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Pipeline.Compile("github", "octocat", "0", nil)
-
 	if err == nil {
 		t.Errorf("Compile returned err: %v", err)
 	}
@@ -292,6 +293,7 @@ func TestPipeline_Expand_200(t *testing.T) {
 	data := []byte(server.ExpandResp)
 
 	var want yaml.Build
+
 	_ = yml.Unmarshal(data, &want)
 
 	// run test
@@ -320,7 +322,6 @@ func TestPipeline_Expand_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Pipeline.Expand("github", "octocat", "0", nil)
-
 	if err == nil {
 		t.Errorf("Expand returned err: %v", err)
 	}
@@ -372,7 +373,6 @@ func TestPipeline_Templates_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Pipeline.Templates("github", "octocat", "0", nil)
-
 	if err == nil {
 		t.Errorf("Templates returned err: %v", err)
 	}
@@ -413,7 +413,6 @@ func TestPipeline_Validate_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Pipeline.Validate("github", "octocat", "0", nil)
-
 	if err == nil {
 		t.Errorf("Validate returned err: %v", err)
 	}

--- a/vela/queue_test.go
+++ b/vela/queue_test.go
@@ -21,6 +21,7 @@ func TestQueue_GetInfo_200(t *testing.T) {
 	s := httptest.NewServer(server.FakeHandler())
 	c, _ := NewClient(s.URL, "", nil)
 	c.Authentication.SetPersonalAccessTokenAuth("token")
+
 	data := []byte(server.QueueInfoResp)
 
 	var want *api.QueueInfo
@@ -56,6 +57,7 @@ func TestQueue_GetInfo_401(t *testing.T) {
 	if err == nil {
 		t.Errorf("GetInfo should have returned err %v", resp.StatusCode)
 	}
+
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("GetInfo returned %v, want %v", resp.StatusCode, http.StatusUnauthorized)
 	}

--- a/vela/repo_test.go
+++ b/vela/repo_test.go
@@ -27,11 +27,11 @@ func TestRepo_Get_200(t *testing.T) {
 	data := []byte(server.RepoResp)
 
 	var want api.Repo
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Repo.Get("github", "octocat")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -56,7 +56,6 @@ func TestRepo_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Repo.Get("github", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -80,11 +79,11 @@ func TestRepo_GetAll_200(t *testing.T) {
 	data := []byte(server.ReposResp)
 
 	var want []api.Repo
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Repo.GetAll(nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -108,6 +107,7 @@ func TestRepo_Add_201(t *testing.T) {
 	data := []byte(server.RepoResp)
 
 	var want api.Repo
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Repo{
@@ -127,7 +127,6 @@ func TestRepo_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Repo.Add(&req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -151,6 +150,7 @@ func TestRepo_Update_200(t *testing.T) {
 	data := []byte(server.RepoResp)
 
 	var want api.Repo
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Repo{
@@ -162,7 +162,6 @@ func TestRepo_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Repo.Update("github", "octocat", &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -194,7 +193,6 @@ func TestRepo_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Repo.Update("github", "not-found", &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -217,7 +215,6 @@ func TestRepo_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Repo.Remove("github", "octocat")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -236,7 +233,6 @@ func TestRepo_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Repo.Remove("github", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -255,7 +251,6 @@ func TestRepo_Repair_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Repo.Repair("github", "octocat")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -274,7 +269,6 @@ func TestRepo_Repair_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Repo.Repair("github", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -293,7 +287,6 @@ func TestRepo_Chown_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Repo.Chown("github", "octocat")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -312,7 +305,6 @@ func TestRepo_Chown_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Repo.Chown("github", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/schedule_test.go
+++ b/vela/schedule_test.go
@@ -16,12 +16,14 @@ import (
 
 func TestSchedule_Get(t *testing.T) {
 	s := httptest.NewServer(server.FakeHandler())
+
 	c, err := NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
 	var schedule api.Schedule
+
 	err = json.Unmarshal([]byte(server.ScheduleResp), &schedule)
 	if err != nil {
 		t.Errorf("unable to create test schedule: %v", err)
@@ -32,6 +34,7 @@ func TestSchedule_Get(t *testing.T) {
 		repo     string
 		schedule string
 	}
+
 	tests := []struct {
 		failure  bool
 		name     string
@@ -91,13 +94,16 @@ func TestSchedule_Get(t *testing.T) {
 
 func TestSchedule_GetAll(t *testing.T) {
 	t.Skip() // server.SchedulesResp is a poorly formatted string. TODO: fix in v0.24
+
 	s := httptest.NewServer(server.FakeHandler())
+
 	c, err := NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
 	var schedules []api.Schedule
+
 	err = json.Unmarshal([]byte(server.SchedulesResp), &schedules)
 	if err != nil {
 		t.Errorf("unable to create test schedules: %v", err)
@@ -108,6 +114,7 @@ func TestSchedule_GetAll(t *testing.T) {
 		repo string
 		opts *ListOptions
 	}
+
 	tests := []struct {
 		failure  bool
 		name     string
@@ -156,12 +163,14 @@ func TestSchedule_GetAll(t *testing.T) {
 
 func TestSchedule_Add(t *testing.T) {
 	s := httptest.NewServer(server.FakeHandler())
+
 	c, err := NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
 	var schedule api.Schedule
+
 	err = json.Unmarshal([]byte(server.ScheduleResp), &schedule)
 	if err != nil {
 		t.Errorf("unable to create test schedule: %v", err)
@@ -172,6 +181,7 @@ func TestSchedule_Add(t *testing.T) {
 		repo     string
 		schedule *api.Schedule
 	}
+
 	tests := []struct {
 		failure  bool
 		name     string
@@ -224,12 +234,14 @@ func TestSchedule_Add(t *testing.T) {
 
 func TestSchedule_Update(t *testing.T) {
 	s := httptest.NewServer(server.FakeHandler())
+
 	c, err := NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create test client: %v", err)
 	}
 
 	var schedule api.Schedule
+
 	err = json.Unmarshal([]byte(server.ScheduleResp), &schedule)
 	if err != nil {
 		t.Errorf("unable to create test schedule: %v", err)
@@ -240,6 +252,7 @@ func TestSchedule_Update(t *testing.T) {
 		repo     string
 		schedule *api.Schedule
 	}
+
 	tests := []struct {
 		failure  bool
 		name     string
@@ -305,6 +318,7 @@ func TestSchedule_Update(t *testing.T) {
 
 func TestSchedule_Remove(t *testing.T) {
 	s := httptest.NewServer(server.FakeHandler())
+
 	c, err := NewClient(s.URL, "", nil)
 	if err != nil {
 		t.Errorf("unable to create test client: %v", err)
@@ -315,6 +329,7 @@ func TestSchedule_Remove(t *testing.T) {
 		repo     string
 		schedule string
 	}
+
 	tests := []struct {
 		failure  bool
 		name     string

--- a/vela/scm_test.go
+++ b/vela/scm_test.go
@@ -21,7 +21,6 @@ func TestSCM_Sync_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.SCM.Sync("github", "octocat")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -39,7 +38,6 @@ func TestSCM_Sync_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.SCM.Sync("github", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -57,7 +55,6 @@ func TestSCM_SyncAll_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.SCM.SyncAll("github")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -75,7 +72,6 @@ func TestSCM_SyncAll_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.SCM.SyncAll("not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/secret_test.go
+++ b/vela/secret_test.go
@@ -27,11 +27,11 @@ func TestSecret_Get_200(t *testing.T) {
 	data := []byte(server.SecretResp)
 
 	var want api.Secret
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Secret.Get("native", "repo", "github", "octocat", "foo")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -56,7 +56,6 @@ func TestSecret_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Secret.Get("native", "repo", "github", "not-found", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -80,11 +79,11 @@ func TestSecret_GetAll_200(t *testing.T) {
 	data := []byte(server.SecretsResp)
 
 	var want []api.Secret
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Secret.GetAll("native", "repo", "github", "octocat", nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -108,6 +107,7 @@ func TestSecret_Add_201(t *testing.T) {
 	data := []byte(server.SecretResp)
 
 	var want api.Secret
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Secret{
@@ -121,7 +121,6 @@ func TestSecret_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Secret.Add("native", "repo", "github", "octocat", &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -145,6 +144,7 @@ func TestSecret_Update_200(t *testing.T) {
 	data := []byte(server.SecretResp)
 
 	var want api.Secret
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Secret{
@@ -155,7 +155,6 @@ func TestSecret_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Secret.Update("native", "repo", "github", "octocat", &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -186,7 +185,6 @@ func TestSecret_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Secret.Update("native", "repo", "github", "not-found", &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -209,7 +207,6 @@ func TestSecret_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Secret.Remove("native", "repo", "github", "octocat", "foo")
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -228,7 +225,6 @@ func TestSecret_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Secret.Remove("native", "repo", "github", "not-found", "not-found")
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/service_test.go
+++ b/vela/service_test.go
@@ -27,11 +27,11 @@ func TestService_Get_200(t *testing.T) {
 	data := []byte(server.ServiceResp)
 
 	var want api.Service
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Svc.Get("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -56,7 +56,6 @@ func TestService_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Svc.Get("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -80,11 +79,11 @@ func TestService_GetAll_200(t *testing.T) {
 	data := []byte(server.ServicesResp)
 
 	var want []api.Service
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Svc.GetAll("github", "octocat", 1, nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -108,6 +107,7 @@ func TestService_Add_201(t *testing.T) {
 	data := []byte(server.ServiceResp)
 
 	var want api.Service
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Service{
@@ -123,7 +123,6 @@ func TestService_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Svc.Add("github", "octocat", 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -147,6 +146,7 @@ func TestService_Update_201(t *testing.T) {
 	data := []byte(server.ServiceResp)
 
 	var want api.Service
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Service{
@@ -158,7 +158,6 @@ func TestService_Update_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Svc.Update("github", "octocat", 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -190,7 +189,6 @@ func TestService_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Svc.Update("github", "not-found", 0, &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -213,7 +211,6 @@ func TestService_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Svc.Remove("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -232,7 +229,6 @@ func TestService_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Svc.Remove("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/step_test.go
+++ b/vela/step_test.go
@@ -27,11 +27,11 @@ func TestStep_Get_200(t *testing.T) {
 	data := []byte(server.StepResp)
 
 	var want api.Step
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Step.Get("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -56,7 +56,6 @@ func TestStep_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Step.Get("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -80,11 +79,11 @@ func TestStep_GetAll_200(t *testing.T) {
 	data := []byte(server.StepsResp)
 
 	var want []api.Step
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Step.GetAll("github", "octocat", 1, nil)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -108,6 +107,7 @@ func TestStep_Add_201(t *testing.T) {
 	data := []byte(server.StepResp)
 
 	var want api.Step
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Step{
@@ -126,7 +126,6 @@ func TestStep_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Step.Add("github", "octocat", 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -150,6 +149,7 @@ func TestStep_Update_201(t *testing.T) {
 	data := []byte(server.StepResp)
 
 	var want api.Step
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Step{
@@ -161,7 +161,6 @@ func TestStep_Update_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Step.Update("github", "octocat", 1, &req)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -193,7 +192,6 @@ func TestStep_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Step.Update("github", "not-found", 0, &req)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -216,7 +214,6 @@ func TestStep_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Step.Remove("github", "octocat", 1, 1)
-
 	if err != nil {
 		t.Errorf("New returned err: %v", err)
 	}
@@ -235,7 +232,6 @@ func TestStep_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Step.Remove("github", "octocat", 1, 0)
-
 	if err == nil {
 		t.Errorf("New returned err: %v", err)
 	}

--- a/vela/user_test.go
+++ b/vela/user_test.go
@@ -25,11 +25,11 @@ func TestUser_Get_200(t *testing.T) {
 	data := []byte(server.UserResp)
 
 	var want api.User
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.User.Get("octocat")
-
 	if err != nil {
 		t.Errorf("User Get returned err: %v", err)
 	}
@@ -54,7 +54,6 @@ func TestUser_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.User.Get("not-found")
-
 	if err == nil {
 		t.Errorf("User Get should have returned err")
 	}
@@ -78,6 +77,7 @@ func TestUser_Update_200(t *testing.T) {
 	data := []byte(server.UserResp)
 
 	var want api.User
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.User{
@@ -86,7 +86,6 @@ func TestUser_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.User.Update("octocat", &req)
-
 	if err != nil {
 		t.Errorf("User Update returned err: %v", err)
 	}
@@ -115,7 +114,6 @@ func TestUser_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.User.Update("not-found", &req)
-
 	if err == nil {
 		t.Errorf("User Update should have returned err")
 	}
@@ -139,11 +137,11 @@ func TestCurrentUser_Get_200(t *testing.T) {
 	data := []byte(server.UserResp)
 
 	var want api.User
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.User.GetCurrent()
-
 	if err != nil {
 		t.Errorf("User GetCurrent returned err: %v", err)
 	}
@@ -170,7 +168,6 @@ func TestUser_GetCurrent_401(t *testing.T) {
 
 	// run test
 	got, resp, err := c.User.GetCurrent()
-
 	if err == nil {
 		t.Errorf("User GetCurrent should have returned err")
 	}
@@ -194,6 +191,7 @@ func TestUser_UpdateCurrent_200(t *testing.T) {
 	data := []byte(server.UserResp)
 
 	var want api.User
+
 	_ = json.Unmarshal(data, &want)
 
 	favorites := []string{"github/octocat"}
@@ -204,7 +202,6 @@ func TestUser_UpdateCurrent_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.User.UpdateCurrent(&req)
-
 	if err != nil {
 		t.Errorf("User UpdateCurrent returned err: %v", err)
 	}
@@ -237,7 +234,6 @@ func TestUser_UpdateCurrent_401(t *testing.T) {
 
 	// run test
 	got, resp, err := c.User.UpdateCurrent(&req)
-
 	if err == nil {
 		t.Errorf("User UpdateCurrent should have returned err")
 	}

--- a/vela/worker_test.go
+++ b/vela/worker_test.go
@@ -26,11 +26,11 @@ func TestWorker_Get_200(t *testing.T) {
 	data := []byte(server.WorkerResp)
 
 	var want api.Worker
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Worker.Get("worker_1")
-
 	if err != nil {
 		t.Errorf("Worker get returned err: %v", err)
 	}
@@ -55,7 +55,6 @@ func TestWorker_Get_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Worker.Get("0")
-
 	if err == nil {
 		t.Errorf("Worker get returned err: %v", err)
 	}
@@ -79,11 +78,11 @@ func TestWorker_GetAll_200(t *testing.T) {
 	data := []byte(server.WorkersResp)
 
 	var want []api.Worker
+
 	_ = json.Unmarshal(data, &want)
 
 	// run test
 	got, resp, err := c.Worker.GetAll(nil)
-
 	if err != nil {
 		t.Errorf("Worker get all returned err: %v", err)
 	}
@@ -107,6 +106,7 @@ func TestWorker_Add_201(t *testing.T) {
 	data := []byte(server.AddWorkerResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Worker{
@@ -124,7 +124,6 @@ func TestWorker_Add_201(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Worker.Add(&req)
-
 	if err != nil {
 		t.Errorf("Worker add returned err: %v", err)
 	}
@@ -148,13 +147,13 @@ func TestWorker_RefreshAuth_200(t *testing.T) {
 	data := []byte(server.AddWorkerResp)
 
 	var want api.Token
+
 	_ = json.Unmarshal(data, &want)
 
 	worker := "worker_1"
 
 	// run test
 	got, resp, err := c.Worker.RefreshAuth(worker)
-
 	if err != nil {
 		t.Errorf("Worker RefreshAuth returned err: %v", err)
 	}
@@ -179,7 +178,6 @@ func TestWorker_RefreshAuth_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Worker.RefreshAuth(worker)
-
 	if err == nil {
 		t.Error("Worker RefreshAuth should have returned err")
 	}
@@ -199,6 +197,7 @@ func TestWorker_Update_200(t *testing.T) {
 	data := []byte(server.WorkerResp)
 
 	var want api.Worker
+
 	_ = json.Unmarshal(data, &want)
 
 	req := api.Worker{
@@ -207,7 +206,6 @@ func TestWorker_Update_200(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Worker.Update("worker_1", &req)
-
 	if err != nil {
 		t.Errorf("Worker update returned err: %v", err)
 	}
@@ -236,7 +234,6 @@ func TestWorker_Update_404(t *testing.T) {
 
 	// run test
 	got, resp, err := c.Worker.Update("0", &req)
-
 	if err == nil {
 		t.Errorf("Worker update returned err: %v", err)
 	}
@@ -259,7 +256,6 @@ func TestWorker_Remove_200(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Worker.Remove("worker_1")
-
 	if err != nil {
 		t.Errorf("Worker remove returned err: %v", err)
 	}
@@ -278,7 +274,6 @@ func TestWorker_Remove_404(t *testing.T) {
 
 	// run test
 	_, resp, err := c.Worker.Remove("0")
-
 	if err == nil {
 		t.Errorf("Worker remove returned err: %v", err)
 	}


### PR DESCRIPTION
Also updated the `wsl` linter to be `wsl_v5` which has auto newline handling, hence the number of "changes"