### PR TITLE
enhance(auth): allow ignoring token refresh

### DIFF
--- a/vela/authentication.go
+++ b/vela/authentication.go
@@ -32,11 +32,17 @@ type AuthenticationService struct {
 	personalAccessToken *string
 	accessToken         *string
 	refreshToken        *string
+	performTokenRefresh *bool
 	scmToken            *string
 	authType            AuthenticationType
 	scmTokenExp         *int64
 	buildRepo           *string
 	buildNumber         *int64
+}
+
+// SetPerformTokenRefresh sets whether or not the client should attempt to refresh tokens when they expire.
+func (s *AuthenticationService) SetPerformTokenRefresh(refreshToken bool) {
+	s.performTokenRefresh = new(refreshToken)
 }
 
 // SetTokenAuth sets the authentication type as a plain token.
@@ -105,6 +111,14 @@ func (svc *AuthenticationService) getAccessToken() (string, error) {
 	}
 
 	return *svc.accessToken, nil
+}
+
+func (svc *AuthenticationService) getPerformTokenRefresh() bool {
+	if svc.performTokenRefresh == nil {
+		return true
+	}
+
+	return *svc.performTokenRefresh
 }
 
 // getRefreshToken returns the active refresh token value or an error.

--- a/vela/authentication.go
+++ b/vela/authentication.go
@@ -113,6 +113,7 @@ func (svc *AuthenticationService) getAccessToken() (string, error) {
 	return *svc.accessToken, nil
 }
 
+// getPerformTokenRefresh returns the perform token refresh value.
 func (svc *AuthenticationService) getPerformTokenRefresh() bool {
 	if svc.performTokenRefresh == nil {
 		return true

--- a/vela/client.go
+++ b/vela/client.go
@@ -210,7 +210,7 @@ func (c *Client) addAuthentication(ctx context.Context, req *http.Request) error
 		}
 
 		isExpired := IsTokenExpired(currentAccess)
-		if isExpired {
+		if isExpired && c.Authentication.getPerformTokenRefresh() {
 			logrus.Debug("access token has expired")
 
 			isRefreshExpired := IsTokenExpired(currentRefresh)


### PR DESCRIPTION
We’ve been exploring the use of the Vela CLI in scenarios where a proxy is involved, with the goal of automatically injecting the refresh and access tokens when requests are sent to the server. In these cases, dummy environment variable values are injected locally so the CLI can still issue the request.

At the moment, this does not work because the existing implementation attempts to parse the refresh token to verify whether it is still valid. Since the locally injected value is something like `12345` rather than a JWT, the validation returns the error of `FATA[0000] your tokens have expired - please log in again with 'vela login'`.

This change introduces a configuration option that allows users to bypass the refresh token validation step. A follow up PR to the CLI will be created to take advantage of this option.